### PR TITLE
Bringing 2l2q_80X back in sync with miniAOD_80X

### DIFF
--- a/AnalysisStep/interface/BTagCalibrationStandalone.h
+++ b/AnalysisStep/interface/BTagCalibrationStandalone.h
@@ -1,0 +1,188 @@
+#ifndef BTagEntry_H
+#define BTagEntry_H
+
+/**
+ *
+ * BTagEntry
+ *
+ * Represents one pt- or discriminator-dependent calibration function.
+ *
+ * measurement_type:    e.g. comb, ttbar, di-mu, boosted, ...
+ * sys_type:            e.g. central, plus, minus, plus_JEC, plus_JER, ...
+ *
+ * Everything is converted into a function, as it is easiest to store it in a
+ * txt or json file.
+ *
+ ************************************************************/
+
+#include <string>
+#include <TF1.h>
+#include <TH1.h>
+
+
+class BTagEntry
+{
+    public:
+    enum OperatingPoint {
+        OP_LOOSE=0,
+        OP_MEDIUM=1,
+        OP_TIGHT=2,
+        OP_RESHAPING=3,
+    };
+    enum JetFlavor {
+        FLAV_B=0,
+        FLAV_C=1,
+        FLAV_UDSG=2,
+    };
+    struct Parameters {
+        OperatingPoint operatingPoint;
+        std::string measurementType;
+        std::string sysType;
+        JetFlavor jetFlavor;
+        float etaMin;
+        float etaMax;
+        float ptMin;
+        float ptMax;
+        float discrMin;
+        float discrMax;
+        
+        // default constructor
+        Parameters(
+                   OperatingPoint op=OP_TIGHT,
+                   std::string measurement_type="comb",
+                   std::string sys_type="central",
+                   JetFlavor jf=FLAV_B,
+                   float eta_min=-99999.,
+                   float eta_max=99999.,
+                   float pt_min=0.,
+                   float pt_max=99999.,
+                   float discr_min=0.,
+                   float discr_max=99999.
+                   );
+        
+    };
+    
+    BTagEntry() {}
+    BTagEntry(const std::string &csvLine);
+    BTagEntry(const std::string &func, Parameters p);
+    BTagEntry(const TF1* func, Parameters p);
+    BTagEntry(const TH1* histo, Parameters p);
+    ~BTagEntry() {}
+    static std::string makeCSVHeader();
+    std::string makeCSVLine() const;
+    static std::string trimStr(std::string str);
+    
+    // public, no getters needed
+    std::string formula;
+    Parameters params;
+    
+};
+
+#endif  // BTagEntry_H
+
+
+#ifndef BTagCalibration_H
+#define BTagCalibration_H
+
+/**
+ * BTagCalibration
+ *
+ * The 'hierarchy' of stored information is this:
+ * - by tagger (BTagCalibration)
+ *   - by operating point or reshape bin
+ *     - by jet parton flavor
+ *       - by type of measurement
+ *         - by systematic
+ *           - by eta bin
+ *             - as 1D-function dependent of pt or discriminant
+ *
+ ************************************************************/
+
+#include <map>
+#include <vector>
+#include <string>
+#include <istream>
+#include <ostream>
+
+
+class BTagCalibration
+{
+    public:
+    BTagCalibration() {}
+    BTagCalibration(const std::string &tagger);
+    BTagCalibration(const std::string &tagger, const std::string &filename);
+    ~BTagCalibration() {}
+    
+    std::string tagger() const {return tagger_;}
+    
+    void addEntry(const BTagEntry &entry);
+    const std::vector<BTagEntry>& getEntries(const BTagEntry::Parameters &par) const;
+    
+    void readCSV(std::istream &s);
+    void readCSV(const std::string &s);
+    void makeCSV(std::ostream &s) const;
+    std::string makeCSV() const;
+    
+    protected:
+    static std::string token(const BTagEntry::Parameters &par);
+    
+    std::string tagger_;
+    std::map<std::string, std::vector<BTagEntry> > data_;
+    
+};
+
+#endif  // BTagCalibration_H
+
+
+#ifndef BTagCalibrationReader_H
+#define BTagCalibrationReader_H
+
+/**
+ * BTagCalibrationReader
+ *
+ * Helper class to pull out a specific set of BTagEntry's out of a
+ * BTagCalibration. TF1 functions are set up at initialization time.
+ *
+ ************************************************************/
+
+#include <memory>
+#include <string>
+
+
+
+class BTagCalibrationReader
+{
+    public:
+    class BTagCalibrationReaderImpl;
+    
+    BTagCalibrationReader() {}
+    BTagCalibrationReader(BTagEntry::OperatingPoint op,
+                          const std::string & sysType="central",
+                          const std::vector<std::string> & otherSysTypes={});
+    
+    void load(const BTagCalibration & c,
+              BTagEntry::JetFlavor jf,
+              const std::string & measurementType="comb");
+    
+    double eval(BTagEntry::JetFlavor jf,
+                float eta,
+                float pt,
+                float discr=0.) const;
+    
+    double eval_auto_bounds(const std::string & sys,
+                            BTagEntry::JetFlavor jf,
+                            float eta,
+                            float pt,
+                            float discr=0.) const;
+    
+    std::pair<float, float> min_max_pt(BTagEntry::JetFlavor jf,
+                                       float eta,
+                                       float discr=0.) const;
+    
+    protected:
+    std::shared_ptr<BTagCalibrationReaderImpl> pimpl;
+};
+
+
+#endif  // BTagCalibrationReader_H
+

--- a/AnalysisStep/interface/BTaggingSFHelper.h
+++ b/AnalysisStep/interface/BTaggingSFHelper.h
@@ -1,9 +1,7 @@
 #ifndef BTAGGINGSFHELPER_H
 #define BTAGGINGSFHELPER_H
 
-#include "CondFormats/BTauObjects/interface/BTagCalibration.h"
-#include "CondFormats/BTauObjects/interface/BTagCalibrationReader.h"
-
+#include "BTagCalibrationStandalone.h"
 #include <string>
 #include <vector>
 #include <utility>
@@ -27,15 +25,10 @@ class BTaggingSFHelper
 
   // related to scale factors
   BTagCalibration* m_calib;
-  BTagCalibrationReader* m_reader_b;
-  BTagCalibrationReader* m_reader_b_up;
-  BTagCalibrationReader* m_reader_b_do;
+  BTagCalibrationReader* m_reader;
+  BTagCalibrationReader* m_reader_up;
+  BTagCalibrationReader* m_reader_do;
   BTagCalibrationReader* m_reader_c;
-  BTagCalibrationReader* m_reader_c_up;
-  BTagCalibrationReader* m_reader_c_do;
-  BTagCalibrationReader* m_reader_udsg;
-  BTagCalibrationReader* m_reader_udsg_up;
-  BTagCalibrationReader* m_reader_udsg_do;
   BTagCalibrationReader* m_readers [3][3]; // [b, c, udsg] [central, up, down]
 
   // related to b tag efficiency

--- a/AnalysisStep/src/BTagCalibrationStandalone.cc
+++ b/AnalysisStep/src/BTagCalibrationStandalone.cc
@@ -1,0 +1,633 @@
+#include "../interface/BTagCalibrationStandalone.h"
+#include <iostream>
+#include <exception>
+#include <algorithm>
+#include <sstream>
+
+
+BTagEntry::Parameters::Parameters(
+                                  OperatingPoint op,
+                                  std::string measurement_type,
+                                  std::string sys_type,
+                                  JetFlavor jf,
+                                  float eta_min,
+                                  float eta_max,
+                                  float pt_min,
+                                  float pt_max,
+                                  float discr_min,
+                                  float discr_max
+                                  ):
+operatingPoint(op),
+measurementType(measurement_type),
+sysType(sys_type),
+jetFlavor(jf),
+etaMin(eta_min),
+etaMax(eta_max),
+ptMin(pt_min),
+ptMax(pt_max),
+discrMin(discr_min),
+discrMax(discr_max)
+{
+    std::transform(measurementType.begin(), measurementType.end(),
+                   measurementType.begin(), ::tolower);
+    std::transform(sysType.begin(), sysType.end(),
+                   sysType.begin(), ::tolower);
+}
+
+BTagEntry::BTagEntry(const std::string &csvLine)
+{
+    // make tokens
+    std::stringstream buff(csvLine);
+    std::vector<std::string> vec;
+    std::string token;
+    while (std::getline(buff, token, ","[0])) {
+        token = BTagEntry::trimStr(token);
+        if (token.empty()) {
+            continue;
+        }
+        vec.push_back(token);
+    }
+    if (vec.size() != 11) {
+        std::cerr << "ERROR in BTagCalibration: "
+        << "Invalid csv line; num tokens != 11: "
+        << csvLine;
+        throw std::exception();
+    }
+    
+    // clean string values
+    char chars[] = " \"\n";
+    for (unsigned int i = 0; i < strlen(chars); ++i) {
+        vec[1].erase(remove(vec[1].begin(),vec[1].end(),chars[i]),vec[1].end());
+        vec[2].erase(remove(vec[2].begin(),vec[2].end(),chars[i]),vec[2].end());
+        vec[10].erase(remove(vec[10].begin(),vec[10].end(),chars[i]),vec[10].end());
+    }
+    
+    // make formula
+    formula = vec[10];
+    TF1 f1("", formula.c_str());  // compile formula to check validity
+    if (f1.IsZombie()) {
+        std::cerr << "ERROR in BTagCalibration: "
+        << "Invalid csv line; formula does not compile: "
+        << csvLine;
+        throw std::exception();
+    }
+    
+    // make parameters
+    unsigned op = stoi(vec[0]);
+    if (op > 3) {
+        std::cerr << "ERROR in BTagCalibration: "
+        << "Invalid csv line; OperatingPoint > 3: "
+        << csvLine;
+        throw std::exception();
+    }
+    unsigned jf = stoi(vec[3]);
+    if (jf > 2) {
+        std::cerr << "ERROR in BTagCalibration: "
+        << "Invalid csv line; JetFlavor > 2: "
+        << csvLine;
+        throw std::exception();
+    }
+    params = BTagEntry::Parameters(
+                                   BTagEntry::OperatingPoint(op),
+                                   vec[1],
+                                   vec[2],
+                                   BTagEntry::JetFlavor(jf),
+                                   stof(vec[4]),
+                                   stof(vec[5]),
+                                   stof(vec[6]),
+                                   stof(vec[7]),
+                                   stof(vec[8]),
+                                   stof(vec[9])
+                                   );
+}
+
+BTagEntry::BTagEntry(const std::string &func, BTagEntry::Parameters p):
+formula(func),
+params(p)
+{
+    TF1 f1("", formula.c_str());  // compile formula to check validity
+    if (f1.IsZombie()) {
+        std::cerr << "ERROR in BTagCalibration: "
+        << "Invalid func string; formula does not compile: "
+        << func;
+        throw std::exception();
+    }
+}
+
+BTagEntry::BTagEntry(const TF1* func, BTagEntry::Parameters p):
+formula(std::string(func->GetExpFormula("p").Data())),
+params(p)
+{
+    if (func->IsZombie()) {
+        std::cerr << "ERROR in BTagCalibration: "
+        << "Invalid TF1 function; function is zombie: "
+        << func->GetName();
+        throw std::exception();
+    }
+}
+
+// Creates chained step functions like this:
+// "<prevous_bin> : x<bin_high_bound ? bin_value : <next_bin>"
+// e.g. "x<0 ? 1 : x<1 ? 2 : x<2 ? 3 : 4"
+std::string th1ToFormulaLin(const TH1* hist) {
+    int nbins = hist->GetNbinsX();
+    TAxis const* axis = hist->GetXaxis();
+    std::stringstream buff;
+    buff << "x<" << axis->GetBinLowEdge(1) << " ? 0. : ";  // default value
+    for (int i=1; i<nbins+1; ++i) {
+        char tmp_buff[50];
+        sprintf(tmp_buff,
+                "x<%g ? %g : ",  // %g is the smaller one of %e or %f
+                axis->GetBinUpEdge(i),
+                hist->GetBinContent(i));
+        buff << tmp_buff;
+    }
+    buff << 0.;  // default value
+    return buff.str();
+}
+
+// Creates step functions making a binary search tree:
+// "x<mid_bin_bound ? (<left side tree>) : (<right side tree>)"
+// e.g. "x<2 ? (x<1 ? (x<0 ? 0:0.1) : (1)) : (x<4 ? (x<3 ? 2:3) : (0))"
+std::string th1ToFormulaBinTree(const TH1* hist, int start=0, int end=-1) {
+    if (end == -1) {                      // initialize
+        start = 0.;
+        end = hist->GetNbinsX()+1;
+        TH1* h2 = (TH1*) hist->Clone();
+        h2->SetBinContent(start, 0);  // kill underflow
+        h2->SetBinContent(end, 0);    // kill overflow
+        std::string res = th1ToFormulaBinTree(h2, start, end);
+        delete h2;
+        return res;
+    }
+    if (start == end) {                   // leave is reached
+        char tmp_buff[20];
+        sprintf(tmp_buff, "%g", hist->GetBinContent(start));
+        return std::string(tmp_buff);
+    }
+    if (start == end - 1) {               // no parenthesis for neighbors
+        char tmp_buff[70];
+        sprintf(tmp_buff,
+                "x<%g ? %g:%g",
+                hist->GetXaxis()->GetBinUpEdge(start),
+                hist->GetBinContent(start),
+                hist->GetBinContent(end));
+        return std::string(tmp_buff);
+    }
+    
+    // top-down recursion
+    std::stringstream buff;
+    int mid = (end-start)/2 + start;
+    char tmp_buff[25];
+    sprintf(tmp_buff,
+            "x<%g ? (",
+            hist->GetXaxis()->GetBinUpEdge(mid));
+    buff << tmp_buff
+    << th1ToFormulaBinTree(hist, start, mid)
+    << ") : ("
+    << th1ToFormulaBinTree(hist, mid+1, end)
+    << ")";
+    return buff.str();
+}
+
+BTagEntry::BTagEntry(const TH1* hist, BTagEntry::Parameters p):
+params(p)
+{
+    int nbins = hist->GetNbinsX();
+    TAxis const* axis = hist->GetXaxis();
+    
+    // overwrite bounds with histo values
+    if (params.operatingPoint == BTagEntry::OP_RESHAPING) {
+        params.discrMin = axis->GetBinLowEdge(1);
+        params.discrMax = axis->GetBinUpEdge(nbins);
+    } else {
+        params.ptMin = axis->GetBinLowEdge(1);
+        params.ptMax = axis->GetBinUpEdge(nbins);
+    }
+    
+    // balanced full binary tree height = ceil(log(2*n_leaves)/log(2))
+    // breakes even around 10, but lower values are more propable in pt-spectrum
+    if (nbins < 15) {
+        formula = th1ToFormulaLin(hist);
+    } else {
+        formula = th1ToFormulaBinTree(hist);
+    }
+    
+    // compile formula to check validity
+    TF1 f1("", formula.c_str());
+    if (f1.IsZombie()) {
+        std::cerr << "ERROR in BTagCalibration: "
+        << "Invalid histogram; formula does not compile (>150 bins?): "
+        << hist->GetName();
+        throw std::exception();
+    }
+}
+
+std::string BTagEntry::makeCSVHeader()
+{
+    return "OperatingPoint, "
+    "measurementType, "
+    "sysType, "
+    "jetFlavor, "
+    "etaMin, "
+    "etaMax, "
+    "ptMin, "
+    "ptMax, "
+    "discrMin, "
+    "discrMax, "
+    "formula \n";
+}
+
+std::string BTagEntry::makeCSVLine() const
+{
+    std::stringstream buff;
+    buff << params.operatingPoint
+    << ", " << params.measurementType
+    << ", " << params.sysType
+    << ", " << params.jetFlavor
+    << ", " << params.etaMin
+    << ", " << params.etaMax
+    << ", " << params.ptMin
+    << ", " << params.ptMax
+    << ", " << params.discrMin
+    << ", " << params.discrMax
+    << ", \"" << formula
+    << "\" \n";
+    return buff.str();
+}
+
+std::string BTagEntry::trimStr(std::string str) {
+    size_t s = str.find_first_not_of(" \n\r\t");
+    size_t e = str.find_last_not_of (" \n\r\t");
+    
+    if((std::string::npos == s) || (std::string::npos == e))
+    return "";
+    else
+    return str.substr(s, e-s+1);
+}
+
+
+#include <fstream>
+#include <sstream>
+
+
+
+BTagCalibration::BTagCalibration(const std::string &taggr):
+tagger_(taggr)
+{}
+
+BTagCalibration::BTagCalibration(const std::string &taggr,
+                                 const std::string &filename):
+tagger_(taggr)
+{
+    std::ifstream ifs(filename);
+    if (!ifs.good()) {
+        std::cerr << "ERROR in BTagCalibration: "
+        << "input file not available: "
+        << filename;
+        throw std::exception();
+    }
+    readCSV(ifs);
+    ifs.close();
+}
+
+void BTagCalibration::addEntry(const BTagEntry &entry)
+{
+    data_[token(entry.params)].push_back(entry);
+}
+
+const std::vector<BTagEntry>& BTagCalibration::getEntries(
+                                                          const BTagEntry::Parameters &par) const
+{
+    std::string tok = token(par);
+    if (!data_.count(tok)) {
+        std::cerr << "ERROR in BTagCalibration: "
+        << "(OperatingPoint, measurementType, sysType) not available: "
+        << tok;
+        throw std::exception();
+    }
+    return data_.at(tok);
+}
+
+void BTagCalibration::readCSV(const std::string &s)
+{
+    std::stringstream buff(s);
+    readCSV(buff);
+}
+
+void BTagCalibration::readCSV(std::istream &s)
+{
+    std::string line;
+    
+    // firstline might be the header
+    getline(s,line);
+    if (line.find("OperatingPoint") == std::string::npos) {
+        addEntry(BTagEntry(line));
+    }
+    
+    while (getline(s,line)) {
+        line = BTagEntry::trimStr(line);
+        if (line.empty()) {  // skip empty lines
+            continue;
+        }
+        addEntry(BTagEntry(line));
+    }
+}
+
+void BTagCalibration::makeCSV(std::ostream &s) const
+{
+    s << tagger_ << ";" << BTagEntry::makeCSVHeader();
+    for (std::map<std::string, std::vector<BTagEntry> >::const_iterator i
+         = data_.cbegin(); i != data_.cend(); ++i) {
+        const std::vector<BTagEntry> &vec = i->second;
+        for (std::vector<BTagEntry>::const_iterator j
+             = vec.cbegin(); j != vec.cend(); ++j) {
+            s << j->makeCSVLine();
+        }
+    }
+}
+
+std::string BTagCalibration::makeCSV() const
+{
+    std::stringstream buff;
+    makeCSV(buff);
+    return buff.str();
+}
+
+std::string BTagCalibration::token(const BTagEntry::Parameters &par)
+{
+    std::stringstream buff;
+    buff << par.operatingPoint << ", "
+    << par.measurementType << ", "
+    << par.sysType;
+    return buff.str();
+}
+
+
+
+
+class BTagCalibrationReader::BTagCalibrationReaderImpl
+{
+    friend class BTagCalibrationReader;
+    
+    public:
+    struct TmpEntry {
+        float etaMin;
+        float etaMax;
+        float ptMin;
+        float ptMax;
+        float discrMin;
+        float discrMax;
+        TF1 func;
+    };
+    
+    private:
+    BTagCalibrationReaderImpl(BTagEntry::OperatingPoint op,
+                              const std::string & sysType,
+                              const std::vector<std::string> & otherSysTypes={});
+    
+    void load(const BTagCalibration & c,
+              BTagEntry::JetFlavor jf,
+              std::string measurementType);
+    
+    double eval(BTagEntry::JetFlavor jf,
+                float eta,
+                float pt,
+                float discr) const;
+    
+    double eval_auto_bounds(const std::string & sys,
+                            BTagEntry::JetFlavor jf,
+                            float eta,
+                            float pt,
+                            float discr) const;
+    
+    std::pair<float, float> min_max_pt(BTagEntry::JetFlavor jf,
+                                       float eta,
+                                       float discr) const;
+    
+    BTagEntry::OperatingPoint op_;
+    std::string sysType_;
+    std::vector<std::vector<TmpEntry> > tmpData_;  // first index: jetFlavor
+    std::vector<bool> useAbsEta_;                  // first index: jetFlavor
+    std::map<std::string, std::shared_ptr<BTagCalibrationReaderImpl>> otherSysTypeReaders_;
+};
+
+
+BTagCalibrationReader::BTagCalibrationReaderImpl::BTagCalibrationReaderImpl(
+                                                                            BTagEntry::OperatingPoint op,
+                                                                            const std::string & sysType,
+                                                                            const std::vector<std::string> & otherSysTypes):
+op_(op),
+sysType_(sysType),
+tmpData_(3),
+useAbsEta_(3, true)
+{
+    for (const std::string & ost : otherSysTypes) {
+        if (otherSysTypeReaders_.count(ost)) {
+            std::cerr << "ERROR in BTagCalibration: "
+            << "Every otherSysType should only be given once. Duplicate: "
+            << ost;
+            throw std::exception();
+        }
+        otherSysTypeReaders_[ost] = std::auto_ptr<BTagCalibrationReaderImpl>(
+                                                                             new BTagCalibrationReaderImpl(op, ost)
+                                                                             );
+    }
+}
+
+void BTagCalibrationReader::BTagCalibrationReaderImpl::load(
+                                                            const BTagCalibration & c,
+                                                            BTagEntry::JetFlavor jf,
+                                                            std::string measurementType)
+{
+    if (tmpData_[jf].size()) {
+        std::cerr << "ERROR in BTagCalibration: "
+        << "Data for this jet-flavor is already loaded: "
+        << jf;
+        throw std::exception();
+    }
+    
+    BTagEntry::Parameters params(op_, measurementType, sysType_);
+    const std::vector<BTagEntry> &entries = c.getEntries(params);
+    
+    for (const auto &be : entries) {
+        if (be.params.jetFlavor != jf) {
+            continue;
+        }
+        
+        TmpEntry te;
+        te.etaMin = be.params.etaMin;
+        te.etaMax = be.params.etaMax;
+        te.ptMin = be.params.ptMin;
+        te.ptMax = be.params.ptMax;
+        te.discrMin = be.params.discrMin;
+        te.discrMax = be.params.discrMax;
+        
+        if (op_ == BTagEntry::OP_RESHAPING) {
+            te.func = TF1("", be.formula.c_str(),
+                          be.params.discrMin, be.params.discrMax);
+        } else {
+            te.func = TF1("", be.formula.c_str(),
+                          be.params.ptMin, be.params.ptMax);
+        }
+        
+        tmpData_[be.params.jetFlavor].push_back(te);
+        if (te.etaMin < 0) {
+            useAbsEta_[be.params.jetFlavor] = false;
+        }
+    }
+    
+    for (auto & p : otherSysTypeReaders_) {
+        p.second->load(c, jf, measurementType);
+    }
+}
+
+double BTagCalibrationReader::BTagCalibrationReaderImpl::eval(
+                                                              BTagEntry::JetFlavor jf,
+                                                              float eta,
+                                                              float pt,
+                                                              float discr) const
+{
+    bool use_discr = (op_ == BTagEntry::OP_RESHAPING);
+    if (useAbsEta_[jf] && eta < 0) {
+        eta = -eta;
+    }
+    
+    // search linearly through eta, pt and discr ranges and eval
+    // future: find some clever data structure based on intervals
+    const auto &entries = tmpData_.at(jf);
+    for (unsigned i=0; i<entries.size(); ++i) {
+        const auto &e = entries.at(i);
+        if (
+            e.etaMin <= eta && eta < e.etaMax                   // find eta
+            && e.ptMin < pt && pt <= e.ptMax                    // check pt
+            ){
+            if (use_discr) {                                    // discr. reshaping?
+                if (e.discrMin <= discr && discr < e.discrMax) {  // check discr
+                    return e.func.Eval(discr);
+                }
+            } else {
+                return e.func.Eval(pt);
+            }
+        }
+    }
+    
+    return 0.;  // default value
+}
+
+double BTagCalibrationReader::BTagCalibrationReaderImpl::eval_auto_bounds(
+                                                                          const std::string & sys,
+                                                                          BTagEntry::JetFlavor jf,
+                                                                          float eta,
+                                                                          float pt,
+                                                                          float discr) const
+{
+    auto sf_bounds = min_max_pt(jf, eta, discr);
+    float pt_for_eval = pt;
+    bool is_out_of_bounds = false;
+    
+    if (pt < sf_bounds.first) {
+        pt_for_eval = sf_bounds.first + .0001;
+        is_out_of_bounds = true;
+    } else if (pt > sf_bounds.second) {
+        pt_for_eval = sf_bounds.second - .0001;
+        is_out_of_bounds = true;
+    }
+    
+    // get central SF (and maybe return)
+    double sf = eval(jf, eta, pt_for_eval, discr);
+    if (sys == sysType_) {
+        return sf;
+    }
+    
+    // get sys SF (and maybe return)
+    if (!otherSysTypeReaders_.count(sys)) {
+        std::cerr << "ERROR in BTagCalibration: "
+        << "sysType not available (maybe not loaded?): "
+        << sys;
+        throw std::exception();
+    }
+    double sf_err = otherSysTypeReaders_.at(sys)->eval(jf, eta, pt_for_eval, discr);
+    if (!is_out_of_bounds) {
+        return sf_err;
+    }
+    
+    // double uncertainty on out-of-bounds and return
+    sf_err = sf + 2*(sf_err - sf);
+    return sf_err;
+}
+
+std::pair<float, float> BTagCalibrationReader::BTagCalibrationReaderImpl::min_max_pt(
+                                                                                     BTagEntry::JetFlavor jf,
+                                                                                     float eta,
+                                                                                     float discr) const
+{
+    bool use_discr = (op_ == BTagEntry::OP_RESHAPING);
+    if (useAbsEta_[jf] && eta < 0) {
+        eta = -eta;
+    }
+    
+    const auto &entries = tmpData_.at(jf);
+    float min_pt = -1., max_pt = -1.;
+    for (const auto & e: entries) {
+        if (
+            e.etaMin <= eta && eta < e.etaMax                   // find eta
+            ){
+            if (min_pt < 0.) {                                  // init
+                min_pt = e.ptMin;
+                max_pt = e.ptMax;
+                continue;
+            }
+            
+            if (use_discr) {                                    // discr. reshaping?
+                if (e.discrMin <= discr && discr < e.discrMax) {  // check discr
+                    min_pt = min_pt < e.ptMin ? min_pt : e.ptMin;
+                    max_pt = max_pt > e.ptMax ? max_pt : e.ptMax;
+                }
+            } else {
+                min_pt = min_pt < e.ptMin ? min_pt : e.ptMin;
+                max_pt = max_pt > e.ptMax ? max_pt : e.ptMax;
+            }
+        }
+    }
+    
+    return std::make_pair(min_pt, max_pt);
+}
+
+
+BTagCalibrationReader::BTagCalibrationReader(BTagEntry::OperatingPoint op,
+                                             const std::string & sysType,
+                                             const std::vector<std::string> & otherSysTypes):
+pimpl(new BTagCalibrationReaderImpl(op, sysType, otherSysTypes)) {}
+
+void BTagCalibrationReader::load(const BTagCalibration & c,
+                                 BTagEntry::JetFlavor jf,
+                                 const std::string & measurementType)
+{
+    pimpl->load(c, jf, measurementType);
+}
+
+double BTagCalibrationReader::eval(BTagEntry::JetFlavor jf,
+                                   float eta,
+                                   float pt,
+                                   float discr) const
+{
+    return pimpl->eval(jf, eta, pt, discr);
+}
+
+double BTagCalibrationReader::eval_auto_bounds(const std::string & sys,
+                                               BTagEntry::JetFlavor jf,
+                                               float eta,
+                                               float pt,
+                                               float discr) const
+{
+    return pimpl->eval_auto_bounds(sys, jf, eta, pt, discr);
+}
+
+std::pair<float, float> BTagCalibrationReader::min_max_pt(BTagEntry::JetFlavor jf,
+                                                          float eta,
+                                                          float discr) const
+{
+    return pimpl->min_max_pt(jf, eta, discr);
+}
+

--- a/AnalysisStep/src/BTaggingSFHelper.cc
+++ b/AnalysisStep/src/BTaggingSFHelper.cc
@@ -1,5 +1,3 @@
-#include "CondFormats/BTauObjects/interface/BTagCalibration.h"
-#include "CondFormats/BTauObjects/interface/BTagCalibrationReader.h"
 #include <FWCore/ParameterSet/interface/FileInPath.h>
 
 #include "../interface/BTaggingSFHelper.h"
@@ -16,27 +14,35 @@ BTaggingSFHelper::BTaggingSFHelper(std::string SFfilename, std::string effFileNa
  
   m_calib = new BTagCalibration("CSVv2", fip_sf.fullPath().c_str());
 
-  m_reader_b    = new BTagCalibrationReader(m_calib , BTagEntry::OP_MEDIUM, "comb", "central");
-  m_reader_b_up = new BTagCalibrationReader(m_calib , BTagEntry::OP_MEDIUM, "comb", "up"     );
-  m_reader_b_do = new BTagCalibrationReader(m_calib , BTagEntry::OP_MEDIUM, "comb", "down"   );
-  m_reader_c    = new BTagCalibrationReader(m_calib , BTagEntry::OP_MEDIUM, "comb", "central");
-  m_reader_c_up = new BTagCalibrationReader(m_calib , BTagEntry::OP_MEDIUM, "comb", "up"     );
-  m_reader_c_do = new BTagCalibrationReader(m_calib , BTagEntry::OP_MEDIUM, "comb", "down"   );
-  m_reader_udsg    = new BTagCalibrationReader(m_calib , BTagEntry::OP_MEDIUM, "incl", "central");
-  m_reader_udsg_up = new BTagCalibrationReader(m_calib , BTagEntry::OP_MEDIUM, "incl", "up"     );
-  m_reader_udsg_do = new BTagCalibrationReader(m_calib , BTagEntry::OP_MEDIUM, "incl", "down"   );
+  m_reader    = new BTagCalibrationReader(BTagEntry::OP_MEDIUM, "central");
+  m_reader_up = new BTagCalibrationReader(BTagEntry::OP_MEDIUM, "up");
+  m_reader_do = new BTagCalibrationReader(BTagEntry::OP_MEDIUM, "down");
 
-  // // [b, c, udsg] [central, up, down]
-  m_readers[0][0] = m_reader_b;
-  m_readers[0][1] = m_reader_b_up;
-  m_readers[0][2] = m_reader_b_do;
-  m_readers[1][0] = m_reader_c;
-  m_readers[1][1] = m_reader_c_up;
-  m_readers[1][2] = m_reader_c_do;
-  m_readers[2][0] = m_reader_udsg;
-  m_readers[2][1] = m_reader_udsg_up;
-  m_readers[2][2] = m_reader_udsg_do;
- 
+  for (int i = 0 ; i < 3; i++) {
+      m_readers[i][0] = m_reader;
+      m_readers[i][1] = m_reader_up;
+      m_readers[i][2] = m_reader_do;
+  }
+
+  for (int i = 0 ; i < 3; i++) {
+      m_readers[i][0] = m_reader;
+      m_readers[i][1] = m_reader_up;
+      m_readers[i][2] = m_reader_do;
+      if (i == 0) {
+	  m_readers[i][0]->load(*m_calib, BTagEntry::FLAV_B, "comb");
+	  m_readers[i][1]->load(*m_calib, BTagEntry::FLAV_B, "comb");
+	  m_readers[i][2]->load(*m_calib, BTagEntry::FLAV_B, "comb");
+      } else if (i == 1) {
+	  m_readers[i][0]->load(*m_calib, BTagEntry::FLAV_C, "comb");
+	  m_readers[i][1]->load(*m_calib, BTagEntry::FLAV_C, "comb");
+	  m_readers[i][2]->load(*m_calib, BTagEntry::FLAV_C, "comb");
+      } else if (i == 2) {
+	  m_readers[i][0]->load(*m_calib, BTagEntry::FLAV_UDSG, "incl");
+	  m_readers[i][1]->load(*m_calib, BTagEntry::FLAV_UDSG, "incl");
+	  m_readers[i][2]->load(*m_calib, BTagEntry::FLAV_UDSG, "incl");
+      }
+  }
+
   edm::FileInPath fip_eff(effFileName);
   m_fileEff = new TFile(fip_eff.fullPath().c_str());
 

--- a/AnalysisStep/test/MasterPy/ZZ2l2qAnalysis.py
+++ b/AnalysisStep/test/MasterPy/ZZ2l2qAnalysis.py
@@ -129,10 +129,13 @@ else:
     from Configuration.AlCa.GlobalTag import GlobalTag
     if IsMC:
         #process.GlobalTag.globaltag = '80X_mcRun2_asymptotic_v3'
-        process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_2016_miniAODv2_v1', '')
+        #process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_2016_miniAODv2_v1', '')
+        process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_2016_TrancheIV_v7', '')
     else:
-        process.GlobalTag = GlobalTag(process.GlobalTag, '80X_dataRun2_Prompt_ICHEP16JEC_v0', '')
-
+        #process.GlobalTag = GlobalTag(process.GlobalTag, '80X_dataRun2_Prompt_ICHEP16JEC_v0', '')
+        process.GlobalTag = GlobalTag(process.GlobalTag, '80X_dataRun2_2016SeptRepro_v6', '')
+        #process.GlobalTag = GlobalTag(process.GlobalTag, '80X_dataRun2_Prompt_v14', '')
+        
 print '\t',process.GlobalTag.globaltag
 
 ### ----------------------------------------------------------------------
@@ -226,7 +229,7 @@ elif (LEPTON_SETUP == 2016):
   #  process.hltFilterTriEle.HLTPaths = ["HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v*"]
   #  process.hltFilterTriMu.HLTPaths = ["HLT_TripleMu_12_10_5_v*"]
     process.hltFilterSingleEle.HLTPaths = ["HLT_Ele25_eta2p1_WPTight_Gsf_v*","HLT_Ele27_WPTight_Gsf_v*","HLT_Ele27_eta2p1_WPLoose_Gsf_v*"]
-    process.hltFilterSingleMu.HLTPaths = ["HLT_IsoMu20_v*","HLT_IsoTkMu20_v*","HLT_IsoMu22_v*","HLT_IsoTkMu22_v*"]
+    process.hltFilterSingleMu.HLTPaths = ["HLT_IsoMu20_v*","HLT_IsoTkMu20_v*","HLT_IsoMu22_v*","HLT_IsoTkMu22_v*","HLT_IsoMu24_v*","HLT_IsoTkMu24_v*"]
    #  process.triggerTriEle = cms.Path(process.hltFilterTriEle)
    #  process.triggerTriMu  = cms.Path(process.hltFilterTriMu )
     process.triggerSingleEle = cms.Path(process.hltFilterSingleEle)

--- a/AnalysisStep/test/prod/samples2l2q_Moriond2017.csv
+++ b/AnalysisStep/test/prod/samples2l2q_Moriond2017.csv
@@ -1,0 +1,91 @@
+identifier,process,crossSection=-1,BR=1,execute=True,dataset,prefix,pattern,splitLevel,::variables,::pyFragments,comment
+
+## Assume cross-section observed by ATLAS at 750 GeV and BR(gg) = BR(ZZ)
+## S (from bkgd-subtracted histogram) is ~ 14
+## sigma = S/(L*eff) ~ 14/(3.2*60%) = 7.3 fb
+## BR(ZZ -> 2l2q) = 2 x 9.9% x 70% = 13.86%
+
+##ggHiggs
+#ggHiggs200, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M200_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs250, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M250_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs300, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M300_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs350, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M350_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs400, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M400_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs450, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M450_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs500, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M500_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs550, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M550_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs600, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M600_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs700, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M700_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs750, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M750_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs800, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M800_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs900, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M900_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs1000, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M1000_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs1500, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M1500_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs2000, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M2000_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs2500, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M2500_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+#ggHiggs3000, ,0.0073,0.1386,,/GluGluHToZZTo2L2Q_M3000_13TeV_powheg2_JHUgenV698_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,10,,,
+
+##VBFHiggs
+#VBFHiggs250, ,0.0073,0.1386,,/VBF_HToZZTo2L2Q_M250_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM,dbs,,10,,,
+#VBFHiggs350, ,0.0073,0.1386,,/VBF_HToZZTo2L2Q_M350_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM,dbs,,10,,,
+#VBFHiggs400, ,0.0073,0.1386,,/VBF_HToZZTo2L2Q_M400_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM,dbs,,10,,,
+#VBFHiggs450, ,0.0073,0.1386,,/VBF_HToZZTo2L2Q_M450_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM,dbs,,10,,,
+#VBFHiggs500, ,0.0073,0.1386,,/VBF_HToZZTo2L2Q_M500_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM,dbs,,10,,,
+#VBFHiggs550, ,0.0073,0.1386,,/VBF_HToZZTo2L2Q_M550_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM,dbs,,10,,,
+#VBFHiggs600, ,0.0073,0.1386,,/VBF_HToZZTo2L2Q_M600_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM,dbs,,10,,,
+#VBFHiggs700, ,0.0073,0.1386,,/VBF_HToZZTo2L2Q_M700_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM,dbs,,10,,,
+#VBFHiggs750, ,0.0073,0.1386,,/VBF_HToZZTo2L2Q_M750_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM,dbs,,10,,,
+#VBFHiggs800, ,0.0073,0.1386,,/VBF_HToZZTo2L2Q_M800_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM,dbs,,10,,,
+#VBFHiggs900, ,0.0073,0.1386,,/VBF_HToZZTo2L2Q_M900_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM,dbs,,10,,,
+#VBFHiggs1000, ,0.0073,0.1386,,/VBF_HToZZTo2L2Q_M1000_13TeV_powheg2_JHUgenV698_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM,dbs,,10,,,
+
+
+## DYjets number of jets - our standard DY jets sample. We also have the "BJet" sample that is enriched in b-jets.
+#DYJetsToLL,,  4895.0,    ,,/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM,dbs,,5,,,
+#DY1Jet,,      1016.0,    ,,/DY1JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+#DY2Jet,,      331.4,    ,,/DY2JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+#DY3Jet,,      96.36,    ,,/DY3JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+#DY4Jet,,      51.4,    ,,/DY4JetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+#DYBJet,,      88.2771,    ,,/DYBJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+
+## DYjets high HT - alternative to the standard DY jets sample
+#DYJetsToLL,,    4895.0,    ,,/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/MINIAODSIM,dbs,,5,,,
+#DYHT70,,      175.30,    ,,/DYJetsToLL_M-50_HT-70to100_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+#DYHT100,,     149.20,    ,,/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+#DYHT200,,     40.99,    ,,/DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+#DYHT400,,     5.678,    ,,/DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+#DYHT600,,     1.367,    ,,/DYJetsToLL_M-50_HT-600to800_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/MINIAODSIM,dbs,,5,,,
+#DYHT800,,     0.6304,    ,,/DYJetsToLL_M-50_HT-800to1200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+#DYHT1200,,    0.1514,    ,,/DYJetsToLL_M-50_HT-1200to2500_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+#DYHT2500,,    0.003565,    ,,/DYJetsToLL_M-50_HT-2500toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+
+
+## Minor backgrounds
+## The POWHEG ttbar sample disappeared :(
+#TTBar,,     87.31,    ,,/TTTo2L2Nu_13TeV-powheg/RunIIFall15MiniAODv1-PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/MINIAODSIM,dbs,,5,,,
+#TTBar,,    57.35,    ,,/TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+#WZDib,,     47.13,    ,,/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+#ZZDib,,     16.523,    ,,/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM,dbs,,5,,,
+## If we need some alternativer samples where we force a leptonic Z decay, we can use these
+#/ZZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM
+#/ZZTo2L2Nu_13TeV_powheg_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM
+#/WZTo2L2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM
+#/WZTo3LNu_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM
+
+
+## Data 25ns, 23Sep2016 Reprocessing
+#DoubleMu2016B,, -1, ,, /DoubleMuon/Run2016B-23Sep2016-v3/MINIAOD,dbs,,7,PD=DoubleMu,cert.py,
+#DoubleMu2016D,, -1, ,, /DoubleMuon/Run2016D-23Sep2016-v1/MINIAOD,dbs,,7,PD=DoubleMu,cert.py, 
+#DoubleMu2016C,, -1, ,, /DoubleMuon/Run2016C-23Sep2016-v1/MINIAOD,dbs,,7,PD=DoubleMu,cert.py,
+#DoubleMu2016F,, -1, ,, /DoubleMuon/Run2016F-23Sep2016-v1/MINIAOD,dbs,,7,PD=DoubleMu,cert.py, 
+#DoubleMu2016E,, -1, ,, /DoubleMuon/Run2016E-23Sep2016-v1/MINIAOD,dbs,,7,PD=DoubleMu,cert.py, 
+#DoubleMu2016G,, -1, ,, /DoubleMuon/Run2016G-23Sep2016-v1/MINIAOD,dbs,,7,PD=DoubleMu,cert.py, 
+#DoubleMu2016H,, -1, ,, /DoubleMuon/Run2016H-PromptReco-v3/MINIAOD,dbs,,7,PD=DoubleMu,cert.py,
+
+#DoubleEG2016B,, -1, ,, /DoubleEG/Run2016B-23Sep2016-v3/MINIAOD,dbs,,10,PD=DoubleEle,cert.py, 
+#DoubleEG2016D,, -1, ,, /DoubleEG/Run2016D-23Sep2016-v1/MINIAOD,dbs,,10,PD=DoubleEle,cert.py,
+#DoubleEG2016C,, -1, ,, /DoubleEG/Run2016C-23Sep2016-v1/MINIAOD,dbs,,10,PD=DoubleEle,cert.py, 
+#DoubleEG2016F,, -1, ,, /DoubleEG/Run2016F-23Sep2016-v1/MINIAOD,dbs,,10,PD=DoubleEle,cert.py, 
+#DoubleEG2016E,, -1, ,, /DoubleEG/Run2016E-23Sep2016-v1/MINIAOD,dbs,,10,PD=DoubleEle,cert.py, 
+#DoubleEG2016G,, -1, ,, /DoubleEG/Run2016G-23Sep2016-v1/MINIAOD,dbs,,10,PD=DoubleEle,cert.py, 
+#DoubleEG2016H,, -1, ,, /DoubleEG/Run2016H-PromptReco-v3/MINIAOD,dbs,,7,PD=DoubleEle,cert.py,

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ZZAnalysis
 
 To install a complete CMSSW area (including this package)
 ------------------------------
-Please use a CMSSW_8_0_X version >= 8_0_4.
+Please use CMSSW_8_0_24_patch1.
 
 Download and execute the setup script:
 ```

--- a/checkout_80X.csh
+++ b/checkout_80X.csh
@@ -1,19 +1,19 @@
 #!/bin/tcsh -fe
 #
 # Instructions:
-# wget -O /tmp/checkout_80X.csh https://raw.githubusercontent.com/CJLST/ZZAnalysis/2l2q_80X/checkout_80X.csh
+# wget -O /tmp/checkout_80X.csh https://raw.githubusercontent.com/CJLST/ZZAnalysis/miniAOD_80X/checkout_80X.csh
 # cd $CMSSW_BASE/src
 # cmsenv
 # source /tmp/checkout_80X.csh
 
 
-############## For CMSSW_8_0_8
+############## For CMSSW_8_0_21
 git cms-init
-# Electron scale recipe according to https://twiki.cern.ch/twiki/bin/view/CMS/EGMSmearer
-git remote add -f -t ecal_smear_fix_80X emanueledimarco https://github.com/emanueledimarco/cmssw.git
+# Preliminary electron scale and smearing corrections according to https://twiki.cern.ch/twiki/bin/view/CMS/EGMSmearer
+git cms-merge-topic -u shervin86:Moriond2017_JEC_energyScales
 git cms-addpkg EgammaAnalysis/ElectronTools
-git checkout -b from-277de3c 277de3c
-(cd EgammaAnalysis/ElectronTools/data ; git clone https://github.com/ECALELFS/ScalesSmearings.git ; git checkout tags/ICHEP2016_v2)
+(cd EgammaAnalysis/ElectronTools/data ; git clone -b master https://github.com/ECALELFS/ScalesSmearings.git)
+
 
 #### Please do not add any custom (non-CMSSW) package before this line ####
 
@@ -22,7 +22,7 @@ git clone https://github.com/Werbellin/RecoEgamma_8X.git RecoEgamma
 (cd RecoEgamma; git checkout d716460) 
 
 #ZZAnalysis
-git clone -b 2l2q_80X https://github.com/CJLST/ZZAnalysis.git ZZAnalysis
+git clone https://github.com/CJLST/ZZAnalysis.git ZZAnalysis
 (cd ZZAnalysis; git checkout 2l2q_80X)
 
 #effective areas (to be updated)
@@ -38,13 +38,16 @@ git clone -n https://github.com/cms-analysis/EgammaAnalysis-ElectronTools EGamma
 
 #MELA
 git clone https://github.com/cms-analysis/HiggsAnalysis-ZZMatrixElement.git ZZMatrixElement
-(cd ZZMatrixElement ; git checkout -b from-v200p5 v2.0.0_patch5 ; cd MELA; ./setup.sh -j 8)
+(cd ZZMatrixElement ; git checkout -b from-v200p5 v2.0.0_patch5)
+# replace ZZMatrixElement/MELA/setup.sh -j 8)
 pushd ${CMSSW_BASE}/src/ZZMatrixElement/MELA/fortran/
 make all
 mv libjhugenmela.so ../data/${SCRAM_ARCH}/
 popd
 
 #kinematic refitting
+#git clone https://github.com/VBF-HZZ/KinZfitter.git
+#(cd KinZfitter ; git checkout -b from-dd5f616 dd5f616)
 git clone https://github.com/tocheng/KinZfitter.git
 (cd KinZfitter; git checkout -b from-Zhadv1.1 Zhadv1.1)
 


### PR DESCRIPTION
I am bringing the 2l2q_80X branch back in sync with the miniAOD_80X branch. The only needed changes where:

- Moving to the new B-tagging infrastructure ("standalone")
- Having the checkout script get the custom KinZfitter from Tongguang

Checked that it compiles cleanly with CMSSW_8_0_24_patch1