### PR TITLE
c constants and fix

### DIFF
--- a/AnalysisStep/interface/cConstants.h
+++ b/AnalysisStep/interface/cConstants.h
@@ -3,6 +3,19 @@
 
 extern "C" float getDVBF2jetsConstant(float ZZMass);
 extern "C" float getDVBF1jetConstant(float ZZMass);
+extern "C" float getDWHhConstant(float ZZMass);
+extern "C" float getDZHhConstant(float ZZMass);
+
+extern "C" float getDVBF2jetsWP(float ZZMass, bool useQGTagging);
+extern "C" float getDVBF1jetWP(float ZZMass, bool useQGTagging);
+extern "C" float getDWHhWP(float ZZMass, bool useQGTagging);
+extern "C" float getDZHhWP(float ZZMass, bool useQGTagging);
+
+extern "C" float getDVBF2jetsConstant_shiftWP(float ZZMass, bool useQGTagging, float newWP);
+extern "C" float getDVBF1jetConstant_shiftWP(float ZZMass, bool useQGTagging, float newWP);
+extern "C" float getDWHhConstant_shiftWP(float ZZMass, bool useQGTagging, float newWP);
+extern "C" float getDZHhConstant_shiftWP(float ZZMass, bool useQGTagging, float newWP);
+
 extern "C" float getDbkgkinConstant(int ZZflav, float ZZMass);
 extern "C" float getDbkgConstant(int ZZflav, float ZZMass);
 

--- a/AnalysisStep/src/Category.cc
+++ b/AnalysisStep/src/Category.cc
@@ -136,23 +136,15 @@ extern "C" int categoryIchep16(
 	     )
 {
 
-  float WP_VBF2j, WP_VBF1j, WP_WHh, WP_ZHh;
-  if(useQGTagging){
-    WP_VBF2j = 0.391;
-    WP_VBF1j = 0.72;
-    WP_WHh = 0.973;
-    WP_ZHh = 0.996;
-  }else{
-    WP_VBF2j = 1.043-460./(ZZMass+634.);
-    WP_VBF1j = 0.699;
-    WP_WHh = 0.959;
-    WP_ZHh = 0.9946;
-  }
+  float WP_VBF2j = getDVBF2jetsWP(ZZMass, useQGTagging);
+  float WP_VBF1j = getDVBF1jetWP(ZZMass, useQGTagging);
+  float WP_WHh = getDWHhWP(ZZMass, useQGTagging);
+  float WP_ZHh = getDZHhWP(ZZMass, useQGTagging);
 
   float c_Mela2j = getDVBF2jetsConstant(ZZMass);
   float c_Mela1j = getDVBF1jetConstant(ZZMass);
-  float c_MelaWH = 1e-3;
-  float c_MelaZH = 1e-4;
+  float c_MelaWH = getDWHhConstant(ZZMass);
+  float c_MelaZH = getDZHhConstant(ZZMass);
 
   float jetPgOverPq[nCleanedJetsPt30];
   for(int j=0; j<nCleanedJetsPt30; j++){

--- a/AnalysisStep/src/cConstants.cc
+++ b/AnalysisStep/src/cConstants.cc
@@ -42,6 +42,62 @@ extern "C" float getDVBF1jetConstant(float ZZMass){
   float constant = kappa/(1.-kappa);
   return constant;
 }
+extern "C" float getDWHhConstant(float ZZMass){
+  return 1e-3;
+}
+extern "C" float getDZHhConstant(float ZZMass){
+  return 1e-4;
+}
+
+extern "C" float getDVBF2jetsWP(float ZZMass, bool useQGTagging){
+  if (useQGTagging)
+    return 0.391;
+  else
+    return 1.043-460./(ZZMass+634.);
+}
+extern "C" float getDVBF1jetWP(float ZZMass, bool useQGTagging){
+  if (useQGTagging)
+    return 0.72;
+  else
+    return 0.699;
+}
+extern "C" float getDWHhWP(float ZZMass, bool useQGTagging){
+  if (useQGTagging)
+    return 0.973;
+  else
+    return 0.959;
+}
+extern "C" float getDZHhWP(float ZZMass, bool useQGTagging){
+  if (useQGTagging)
+    return 0.996;
+  else
+    return 0.9946;
+}
+
+extern "C" float getDVBF2jetsConstant_shiftWP(float ZZMass, bool useQGTagging, float newWP) {
+  float oldc = getDVBF2jetsConstant(ZZMass);
+  float oldWP = getDVBF2jetsWP(ZZMass, useQGTagging);
+  return oldc * (newWP/oldWP) * ((1-oldWP)/(1-newWP));
+}
+extern "C" float getDVBF1jetConstant_shiftWP(float ZZMass, bool useQGTagging, float newWP) {
+  float oldc = getDVBF1jetConstant(ZZMass);
+  float oldWP = getDVBF1jetWP(ZZMass, useQGTagging);
+  return oldc * (newWP/oldWP) * ((1-oldWP)/(1-newWP));
+}
+
+extern "C" float getDWHhConstant_shiftWP(float ZZMass, bool useQGTagging, float newWP) {
+  float oldc = getDWHhConstant(ZZMass);
+  float oldWP = getDWHhWP(ZZMass, useQGTagging);
+  return oldc * (newWP/oldWP) * ((1-oldWP)/(1-newWP));
+}
+
+extern "C" float getDZHhConstant_shiftWP(float ZZMass, bool useQGTagging, float newWP) {
+  float oldc = getDZHhConstant(ZZMass);
+  float oldWP = getDZHhWP(ZZMass, useQGTagging);
+  return oldc * (newWP/oldWP) * ((1-oldWP)/(1-newWP));
+}
+
+
 extern "C" float getDbkgkinConstant(int ZZflav, float ZZMass){ // ZZflav==id1*id2*id3*id4
   float par[14]={
     0.775,

--- a/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
+++ b/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
@@ -1147,7 +1147,12 @@ void HZZ4lNtupleMaker::FillLHECandidate(){
           MELAParticle* Vij = Vi->getDaughter(iVj);
           if (Vij!=0){
             LHEDaughterPt.push_back(Vij->pt());
-            LHEDaughterEta.push_back(Vij->eta());
+            if (abs(Vij->pt() / Vij->z()) > 2e-8) {
+              LHEDaughterEta.push_back(Vij->eta());
+            } else {
+              edm::LogWarning("ZeroPt") << "pt = 0!  Using eta = +/-1e10\n" << Vij->id << " " << Vij->x() << " " << Vij->y() << " " << Vij->z() << " " << Vij->t();
+              LHEDaughterEta.push_back(copysign(1e10, Vij->z()));
+            }
             LHEDaughterPhi.push_back(Vij->phi());
             LHEDaughterMass.push_back(Vij->m());
             LHEDaughterId.push_back((short)Vij->id);
@@ -1184,7 +1189,12 @@ void HZZ4lNtupleMaker::FillLHECandidate(){
       MELAParticle* apart = AssociatedParticle.at(aa);
       if (apart!=0){
         LHEAssociatedParticlePt.push_back(apart->pt());
-        LHEAssociatedParticleEta.push_back(apart->eta());
+        if (abs(apart->pt() / apart->z()) > 2e-8) {
+          LHEAssociatedParticleEta.push_back(apart->eta());
+        } else {
+          edm::LogWarning("ZeroPt") << "pt = 0!  Using eta = +/-1e10\n" << apart->id << " " << apart->x() << " " << apart->y() << " " << apart->z() << " " << apart->t();
+          LHEAssociatedParticleEta.push_back(copysign(1e10, apart->z()));
+        }
         LHEAssociatedParticlePhi.push_back(apart->phi());
         LHEAssociatedParticleMass.push_back(apart->m());
         LHEAssociatedParticleId.push_back((short)apart->id);

--- a/AnalysisStep/test/syncUtils.py
+++ b/AnalysisStep/test/syncUtils.py
@@ -88,6 +88,8 @@ class KDs:
         lib.getDbkgConstant.restype = ctypes.c_float
         lib.getDVBF2jetsConstant.restype = ctypes.c_float
         lib.getDVBF1jetConstant.restype = ctypes.c_float
+        lib.getDWHhConstant.restype = ctypes.c_float
+        lib.getDZHhConstant.restype = ctypes.c_float
 
         self.D_bkg_kin  = self.p_GG_SIG_ghg2_1_ghz1_1_JHUGen/(self.p_GG_SIG_ghg2_1_ghz1_1_JHUGen + self.p_QQB_BKG_MCFM*lib.getDbkgkinConstant(c_int(int(self.ZZFlav)),c_float(self.ZZMass)))
         self.D_bkg      = self.p_GG_SIG_ghg2_1_ghz1_1_JHUGen*self.p_m4l_SIG/(self.p_GG_SIG_ghg2_1_ghz1_1_JHUGen*self.p_m4l_SIG+self.p_QQB_BKG_MCFM*self.p_m4l_BKG*lib.getDbkgConstant(c_int(int(self.ZZFlav)),c_float(self.ZZMass)))
@@ -100,8 +102,8 @@ class KDs:
         ##MELA-only production discriminants:
         if self.njets30 >= 2 :
             self.Djet_VAJHU = self.p_JJVBF_SIG_ghv1_1_JHUGen_JECNominal/(self.p_JJVBF_SIG_ghv1_1_JHUGen_JECNominal+self.p_JJQCD_SIG_ghg2_1_JHUGen_JECNominal*lib.getDVBF2jetsConstant(c_float(self.ZZMass))) # VBF(2j) vs. gg->H+2j
-            self.D_WHh_VAJHU   = self.p_HadWH_SIG_ghw1_1_JHUGen_JECNominal/(self.p_HadWH_SIG_ghw1_1_JHUGen_JECNominal+1e-3*self.p_JJQCD_SIG_ghg2_1_JHUGen_JECNominal) # W(->2j)H vs. gg->H+2j
-            self.D_ZHh_VAJHU   = self.p_HadZH_SIG_ghz1_1_JHUGen_JECNominal/(self.p_HadZH_SIG_ghz1_1_JHUGen_JECNominal+1e-4*self.p_JJQCD_SIG_ghg2_1_JHUGen_JECNominal) # Z(->2j)H vs. gg->H+2j
+            self.D_WHh_VAJHU   = self.p_HadWH_SIG_ghw1_1_JHUGen_JECNominal/(self.p_HadWH_SIG_ghw1_1_JHUGen_JECNominal+lib.getDWHhConstant(c_float(self.ZZMass))*self.p_JJQCD_SIG_ghg2_1_JHUGen_JECNominal) # W(->2j)H vs. gg->H+2j
+            self.D_ZHh_VAJHU   = self.p_HadZH_SIG_ghz1_1_JHUGen_JECNominal/(self.p_HadZH_SIG_ghz1_1_JHUGen_JECNominal+lib.getDZHhConstant(c_float(self.ZZMass))*self.p_JJQCD_SIG_ghg2_1_JHUGen_JECNominal) # Z(->2j)H vs. gg->H+2j
         if self.njets30 == 1 :
             self.D_VBF1j_VAJHU = self.p_JVBF_SIG_ghv1_1_JHUGen_JECNominal*self.pAux_JVBF_SIG_ghv1_1_JHUGen_JECNominal/(self.p_JVBF_SIG_ghv1_1_JHUGen_JECNominal*self.pAux_JVBF_SIG_ghv1_1_JHUGen_JECNominal+self.p_JQCD_SIG_ghg2_1_JHUGen_JECNominal*lib.getDVBF1jetConstant(c_float(self.ZZMass))) # VBF(1j) vs. gg->H+1j
         ##MELA+q/g production discriminants:


### PR DESCRIPTION
WPs as functions in cConstants.cc, and functions to get the c constant for shifted WP.  Synchronizer output doesn't change.

Fix for a very rare bug which happens in ggH125_scaledown_minloHJJ_Chunk0.  One of the associated jets has eta of infinity by accident and root was throwing an error.