### PR TITLE
LHE weights for 2017 MC

### DIFF
--- a/AnalysisStep/interface/ExtendedBranch.h
+++ b/AnalysisStep/interface/ExtendedBranch.h
@@ -121,7 +121,8 @@ namespace BranchHelpers{
     }
     void createBranch(varType* defVal_){
       if (!isVector && defVal_!=0){
-        if (defVal!=0) delete defVal; defVal = new varType;
+        if (defVal!=0) delete defVal;
+        defVal = new varType;
         *defVal = *defVal_;
       }
       reset();

--- a/AnalysisStep/interface/LHEHandler.h
+++ b/AnalysisStep/interface/LHEHandler.h
@@ -66,7 +66,7 @@ protected:
   MELAEvent* genEvent;
   MELACandidate* genCand;
 
-  int defaultNLOweight;
+  float defaultNLOweight;
   float LHEOriginalWeight;
   vector<float> LHEWeight;
   vector<float> LHEWeight_PDFVariationUpDn;

--- a/AnalysisStep/interface/LHEHandler.h
+++ b/AnalysisStep/interface/LHEHandler.h
@@ -34,8 +34,8 @@
 class LHEHandler{
 public:
 
-  LHEHandler(int VVMode_, int VVDecayMode_, bool doKinematics_);
-  LHEHandler(edm::Handle<LHEEventProduct>* lhe_evt_, int VVMode_, int VVDecayMode_, bool doKinematics_);
+  LHEHandler(int VVMode_, int VVDecayMode_, bool doKinematics_, int year_);
+  LHEHandler(edm::Handle<LHEEventProduct>* lhe_evt_, int VVMode_, int VVDecayMode_, bool doKinematics_, int year_);
   virtual ~LHEHandler();
   
   void setHandle(edm::Handle<LHEEventProduct>* lhe_evt_);
@@ -48,22 +48,25 @@ public:
   float getLHEWeight_PDFVariationUpDn(int whichUpDn, float defaultValue=1) const; // = {Weights written in LHE weight variations} / getLHEOriginalWeight()
   float getLHEWeigh_AsMZUpDn(int whichUpDn, float defaultValue=1) const; // = {Weights written in LHE weight variations} / getLHEOriginalWeight()
   float const& getPDFScale() const;
+  float reweightNNLOtoNLO() const;
 
-  static void addByLowestInAbs(float val, std::vector<float>& valArray);
+  static bool compareAbs(float val1, float val2);
   static float findNearestOneSigma(float ref, int lowhigh, std::vector<float> const& wgt_array);
 
 protected:
 
   // VVMode and VVDecayMode: See comment lines within MELAEvent::constructVVCandidates
-  int VVMode;
-  int VVDecayMode;
-  bool doKinematics;
+  const int VVMode;
+  const int VVDecayMode;
+  const bool doKinematics;
+  const int year;
 
   edm::Handle<LHEEventProduct>* lhe_evt;
   vector<MELAParticle*> particleList;
   MELAEvent* genEvent;
   MELACandidate* genCand;
 
+  int defaultNLOweight;
   float LHEOriginalWeight;
   vector<float> LHEWeight;
   vector<float> LHEWeight_PDFVariationUpDn;

--- a/AnalysisStep/src/LHEHandler.cc
+++ b/AnalysisStep/src/LHEHandler.cc
@@ -228,7 +228,7 @@ void LHEHandler::readEvent(){
   }
 
   if (LHEPDFVariationWgt.size() > 100) {
-    auto firstalphasweight = LHEPDFVariationWgt.begin() + 99; //= iterator to LHEPDFVariationWgt[99] = 100th entry
+    auto firstalphasweight = LHEPDFVariationWgt.begin() + 100; //= iterator to LHEPDFVariationWgt[100] = 101st entry
     LHEPDFAlphaSMZWgt.assign(firstalphasweight, LHEPDFVariationWgt.end());
     LHEPDFVariationWgt.erase(firstalphasweight, LHEPDFVariationWgt.end());
   }
@@ -259,7 +259,7 @@ void LHEHandler::readEvent(){
         float centralWeight = defaultNLOweight;
 
         float errorsquared = 0;
-        for (auto wt : LHEPDFVariationWgt) {
+        for (const auto& wt : LHEPDFVariationWgt) {
           float difference = wt - centralWeight;
           errorsquared += difference*difference;
         }

--- a/AnalysisStep/src/LHEHandler.cc
+++ b/AnalysisStep/src/LHEHandler.cc
@@ -197,6 +197,9 @@ void LHEHandler::readEvent(){
       else if (wgtid<3000) LHEPDFVariationWgt.push_back(wgtval); // Add PDF replicas and alphas(mZ) variations from the same pdf
     } else if (year == 2017) {
       if (1001 <= wgtid && wgtid <= 1009) LHEWeight.push_back(wgtval);
+      else if (1500 <= wgtid && wgtid <= 1602) {/*do nothing, these are the NLO pdf for NNPDF30 and variations*/}
+      else if (wgtid == 1700)                  {/*do nothing, this is the NNLO pdf for NNPDF30*/}
+      else if (wgtid == 1800 || wgtid == 1850 || wgtid == 1900 || wgtid == 1950) {/*do nothing, these are LO pdfs*/}
       else if (2000 <= wgtid && wgtid <= 2111) {/*do nothing, these are the NNLO variations*/}
       else if (wgtid == 3000) {founddefaultNLOweight = true; defaultNLOweight = wgtval;}
       else if (3001 <= wgtid && wgtid <= 3102) LHEPDFVariationWgt.push_back(wgtval);

--- a/AnalysisStep/src/LHEHandler.cc
+++ b/AnalysisStep/src/LHEHandler.cc
@@ -264,15 +264,15 @@ void LHEHandler::readEvent(){
           errorsquared += difference*difference;
         }
         float error = sqrt(errorsquared);
-        LHEWeight_PDFVariationUpDn = {error, error};
+        LHEWeight_PDFVariationUpDn = {(centralWeight + error) / reweightNNLOtoNLO(), (centralWeight - error) / reweightNNLOtoNLO()};
 
         if (LHEPDFAlphaSMZWgt.size()>1){
           float asdn = LHEPDFAlphaSMZWgt.at(0);
           float asup = LHEPDFAlphaSMZWgt.at(1);
           // Rescale alphas(mZ) variations from 0.118+-0.002 to 0.118+-0.0015
           //                           Note this number ^ is different than 2016!
-          LHEWeight_AsMZUpDn.push_back(centralWeight + (asup-centralWeight)*0.75);
-          LHEWeight_AsMZUpDn.push_back(centralWeight + (asdn-centralWeight)*0.75);
+          LHEWeight_AsMZUpDn.push_back((centralWeight + (asup-centralWeight)*0.75) / reweightNNLOtoNLO());
+          LHEWeight_AsMZUpDn.push_back((centralWeight + (asdn-centralWeight)*0.75) / reweightNNLOtoNLO());
         }
         break;
       }

--- a/AnalysisStep/src/LHEHandler.cc
+++ b/AnalysisStep/src/LHEHandler.cc
@@ -187,7 +187,12 @@ void LHEHandler::readEvent(){
   vector<float> LHEPDFVariationWgt;
   bool founddefaultNLOweight = false;
   for (const auto& weight : (*lhe_evt)->weights()) {
-    int wgtid=atoi(weight.id.c_str());
+    int wgtid;
+    try {
+      wgtid = stoi(weight.id.c_str());
+    } catch (std::invalid_argument& e) {
+      continue;  //we don't use non-numerical indices, but they exist in some 2016 MC samples
+    }
     float wgtval=weight.wgt / LHEOriginalWeight;
     //cout << "PDF id = " << PDFid.at(0) << " " << wgtid << " -> " << wgtval << endl;
     if (year == 2016) {

--- a/AnalysisStep/src/LHEHandler.cc
+++ b/AnalysisStep/src/LHEHandler.cc
@@ -185,12 +185,10 @@ void LHEHandler::readEvent(){
   LHEOriginalWeight = (*lhe_evt)->originalXWGTUP();
   vector<float> LHEPDFAlphaSMZWgt;
   vector<float> LHEPDFVariationWgt;
-  bool foundanyweights = !(*lhe_evt)->weights().empty();
   bool founddefaultNLOweight = false;
   for (const auto& weight : (*lhe_evt)->weights()) {
     int wgtid=atoi(weight.id.c_str());
     float wgtval=weight.wgt / LHEOriginalWeight;
-    foundanyweights = true;
     //cout << "PDF id = " << PDFid.at(0) << " " << wgtid << " -> " << wgtval << endl;
     if (year == 2016) {
       if (wgtid<2000) LHEWeight.push_back(wgtval);
@@ -209,7 +207,7 @@ void LHEHandler::readEvent(){
     }
   }
 
-  if (year == 2017 && foundanyweights && !(founddefaultNLOweight && LHEWeight.size() == 9 && LHEPDFVariationWgt.size() == 102)) {
+  if (year == 2017 && !(*lhe_evt)->weights().empty() && !(founddefaultNLOweight && LHEWeight.size() == 9 && LHEPDFVariationWgt.size() == 102)) {
     throw cms::Exception("LHEWeights")
             << "For 2017 MC, expect to find either\n"
             << " - no alternate LHE weights, or\n"

--- a/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
+++ b/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
@@ -229,6 +229,7 @@ namespace {
   Short_t genFinalState  = 0;
   Int_t genProcessId  = 0;
   Float_t genHEPMCweight  = 0;
+  Float_t genHEPMCweight_NNLO  = 0;
 
   std::vector<float> LHEMotherPz;
   std::vector<float> LHEMotherE;
@@ -446,6 +447,7 @@ private:
   edm::EDGetTokenT<HTXS::HiggsClassification> htxsToken;
   #endif
   edm::EDGetTokenT<edm::MergeableCounter> preSkimToken;
+  edm::EDGetTokenT<LHERunInfoProduct> lheRunInfoToken;
 
   PileUpWeight pileUpReweight;
 
@@ -558,6 +560,7 @@ HZZ4lNtupleMaker::HZZ4lNtupleMaker(const edm::ParameterSet& pset) :
   muonToken = consumes<pat::MuonCollection>(edm::InputTag("slimmedMuons"));
   electronToken = consumes<pat::ElectronCollection>(edm::InputTag("slimmedElectrons"));
   preSkimToken = consumes<edm::MergeableCounter,edm::InLumi>(edm::InputTag("preSkimCounter"));
+  lheRunInfoToken = consumes<LHERunInfoProduct,edm::InRun>(edm::InputTag("externalLHEProducer"));
 
   if (skipEmptyEvents) {
     applySkim=true;
@@ -573,7 +576,7 @@ HZZ4lNtupleMaker::HZZ4lNtupleMaker(const edm::ParameterSet& pset) :
 
   isMC = myHelper.isMC();
   addLHEKinematics = addLHEKinematics || lheMElist.size()>0;
-  if (isMC) lheHandler = new LHEHandler(pset.getParameter<int>("VVMode"), pset.getParameter<int>("VVDecayMode"), addLHEKinematics);
+  if (isMC) lheHandler = new LHEHandler(pset.getParameter<int>("VVMode"), pset.getParameter<int>("VVDecayMode"), addLHEKinematics, year);
 	if (isMC)
 	{
 		#if CMSSW_VERSION_MAJOR<9
@@ -770,7 +773,8 @@ void HZZ4lNtupleMaker::analyze(const edm::Event& event, const edm::EventSetup& e
     MCHistoryTools mch(event, sampleName, genParticles, genInfo);
     genFinalState = mch.genFinalState();
     genProcessId = mch.getProcessID();
-    genHEPMCweight = mch.gethepMCweight(); // Overridden by LHEHandler if genHEPMCweight==1.
+    genHEPMCweight_NNLO = genHEPMCweight = mch.gethepMCweight(); // Overridden by LHEHandler if genHEPMCweight==1.
+                                                                 // For 2017 MC, genHEPMCweight is reweighted later from NNLO to NLO
     genExtInfo = mch.genAssociatedFS();
 
     //Information on generated candidates, will be used later
@@ -1351,6 +1355,10 @@ void HZZ4lNtupleMaker::FillLHECandidate(){
       edm::LogWarning("InconsistentWeights") << "Gen weight is 1, LHE weight is " << genHEPMCweight;
     }
   }
+  if (year == 2017) {
+    genHEPMCweight *= lheHandler->reweightNNLOtoNLO();
+  }
+
   LHEweight_QCDscale_muR1_muF1 = lheHandler->getLHEWeight(0, 1.);
   LHEweight_QCDscale_muR1_muF2 = lheHandler->getLHEWeight(1, 1.);
   LHEweight_QCDscale_muR1_muF0p5 = lheHandler->getLHEWeight(2, 1.);
@@ -1729,24 +1737,23 @@ void HZZ4lNtupleMaker::endJob()
 // ------------ method called when starting to processes a run  ------------
 void HZZ4lNtupleMaker::beginRun(edm::Run const& iRun, edm::EventSetup const&)
 {
-  // // code that helps find the indices of LHE weights
-  // edm::Handle<LHERunInfoProduct> run;
-  // typedef std::vector<LHERunInfoProduct::Header>::const_iterator headers_const_iterator;
-  // iRun.getByLabel( "externalLHEProducer", run );
-  // LHERunInfoProduct myLHERunInfoProduct = *(run.product());
-  // for (headers_const_iterator iter=myLHERunInfoProduct.headers_begin(); iter!=myLHERunInfoProduct.headers_end(); iter++){
-  //   std::cout << iter->tag() << std::endl;
-  //   std::vector<std::string> lines = iter->lines();
-  //   for (unsigned int iLine = 0; iLine<lines.size(); iLine++) {
-  //     std::cout << lines.at(iLine);
-  //   }
-  // }
-
 }
 
 // ------------ method called when ending the processing of a run  ------------
-void HZZ4lNtupleMaker::endRun(edm::Run const&, edm::EventSetup const&)
+void HZZ4lNtupleMaker::endRun(edm::Run const& iRun, edm::EventSetup const&)
 {
+  // code that helps find the indices of LHE weights
+  edm::Handle<LHERunInfoProduct> run;
+  typedef std::vector<LHERunInfoProduct::Header>::const_iterator headers_const_iterator;
+  iRun.getByToken(lheRunInfoToken, run);
+  LHERunInfoProduct myLHERunInfoProduct = *(run.product());
+  for (headers_const_iterator iter=myLHERunInfoProduct.headers_begin(); iter!=myLHERunInfoProduct.headers_end(); iter++){
+    std::cout << iter->tag() << std::endl;
+    std::vector<std::string> lines = iter->lines();
+    for (unsigned int iLine = 0; iLine<lines.size(); iLine++) {
+      std::cout << lines.at(iLine);
+    }
+  }
 }
 
 // ------------ method called when starting to processes a luminosity block  ------------
@@ -2197,6 +2204,7 @@ void HZZ4lNtupleMaker::BookAllBranches(){
     myTree->Book("genFinalState", genFinalState, failedTreeLevel >= minimalFailedTree);
     myTree->Book("genProcessId", genProcessId, failedTreeLevel >= minimalFailedTree);
     myTree->Book("genHEPMCweight", genHEPMCweight, failedTreeLevel >= minimalFailedTree);
+    if (year == 2017) myTree->Book("genHEPMCweight_NNLO", genHEPMCweight_NNLO, failedTreeLevel >= minimalFailedTree);
     myTree->Book("PUWeight", PUWeight, failedTreeLevel >= minimalFailedTree);
     myTree->Book("PUWeight_Dn", PUWeight_Dn, failedTreeLevel >= minimalFailedTree);
     myTree->Book("PUWeight_Up", PUWeight_Up, failedTreeLevel >= minimalFailedTree);

--- a/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
+++ b/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
@@ -1742,6 +1742,7 @@ void HZZ4lNtupleMaker::beginRun(edm::Run const& iRun, edm::EventSetup const&)
 // ------------ method called when ending the processing of a run  ------------
 void HZZ4lNtupleMaker::endRun(edm::Run const& iRun, edm::EventSetup const&)
 {
+/*
   // code that helps find the indices of LHE weights
   edm::Handle<LHERunInfoProduct> run;
   typedef std::vector<LHERunInfoProduct::Header>::const_iterator headers_const_iterator;
@@ -1754,6 +1755,7 @@ void HZZ4lNtupleMaker::endRun(edm::Run const& iRun, edm::EventSetup const&)
       std::cout << lines.at(iLine);
     }
   }
+*/
 }
 
 // ------------ method called when starting to processes a luminosity block  ------------

--- a/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
+++ b/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
@@ -1349,7 +1349,7 @@ void HZZ4lNtupleMaker::FillLHECandidate(){
 
   LHEPDFScale = lheHandler->getPDFScale();
   if (genHEPMCweight==1.) {
-    genHEPMCweight = lheHandler->getLHEOriginalWeight();
+    genHEPMCweight_NNLO = genHEPMCweight = lheHandler->getLHEOriginalWeight();
     if (!printedLHEweightwarning && genHEPMCweight!=1) {
       printedLHEweightwarning = true;
       edm::LogWarning("InconsistentWeights") << "Gen weight is 1, LHE weight is " << genHEPMCweight;


### PR DESCRIPTION
For 2017 MC:
- genHEPMCweight = default weight * (NLO pdf weight) / (NNLO pdf weight)
- genHEPMCweight_NNLO = default weight
  - This should not be used for anything except debugging.  It doesn't have any physical meaning.  We can probably remove it at some point
- Uncertainties:
    - all of them should be multiplied by genHEPMCweight, as was previously done
    - QCD scale uncertainties are for the NNLO pdf with varied muR and muF.  The variations for the NLO pdf are not provided.  We have to assume it factorizes.
    - PDF variations are now done with the Hessian method, see the links in the code.  They are for the NLO pdf and are symmetric.  They are divided by the NNLO-->NLO correction factor so that they can be multiplied by genHEPMCweight (which includes this factor), as was done previously.
    - alphas variations are also for the NLO pdf, with the same story about the correction factor

I put some fairly strict checks on what weights should and should not exist in the header, and the job will fail if the expected weights don't exist (unless there are no alternate weights, as in the case of MCFM or JHUGen) or if extra alternate weights with low indices exist.  I think this is subtle enough that we really don't want to make mistakes, so strict sanity checks are necessary.

I tested 2017 POWHEG and MCFM, and they work.  I also checked that 2016 samples for both POWHEG and MCFM give exactly the same tree content as they used to.