### PR TITLE
 store POWHEG original weight, better normalization for systematics

### DIFF
--- a/AnalysisStep/interface/LHEHandler.h
+++ b/AnalysisStep/interface/LHEHandler.h
@@ -44,6 +44,7 @@ public:
 
   MELACandidate* getBestCandidate();
   float const& getLHEOriginalWeight() const; // Weight written in the <event> block, supposed to = genhepmcweight if no Pythia reweighting is done
+  float const& getPowhegOriginalWeight() const; // Weight from POWHEG before JHUGen reweighting, taken from alternate weight 1001.  If there are no alternate weights this is the same as the LHEOriginalWeight
   float getLHEWeight(unsigned int whichWeight, float defaultValue=1) const; // = {Weights written in LHE weight variations} / getLHEOriginalWeight()
   float getLHEWeight_PDFVariationUpDn(int whichUpDn, float defaultValue=1) const; // = {Weights written in LHE weight variations} / getLHEOriginalWeight()
   float getLHEWeigh_AsMZUpDn(int whichUpDn, float defaultValue=1) const; // = {Weights written in LHE weight variations} / getLHEOriginalWeight()
@@ -68,6 +69,7 @@ protected:
 
   float defaultNLOweight;
   float LHEOriginalWeight;
+  float powhegOriginalWeight;
   vector<float> LHEWeight;
   vector<float> LHEWeight_PDFVariationUpDn;
   vector<float> LHEWeight_AsMZUpDn;

--- a/AnalysisStep/src/LHEHandler.cc
+++ b/AnalysisStep/src/LHEHandler.cc
@@ -266,12 +266,11 @@ void LHEHandler::readEvent(){
         if (centralWeight == 0) {
           LHEWeight_PDFVariationUpDn = {0, 0};
           LHEWeight_AsMZUpDn = {0, 0};
-          //can't do auto warning = edm::LogWarning("ZeroWeight") because https://github.com/cms-sw/cmssw/blob/beefd9848d9cf4d4ed373d420bacd91a265f8737/FWCore/MessageLogger/interface/MessageLogger.h#L161
-          auto warning = std::make_unique<edm::LogWarning>("ZeroWeight");
-          *warning << "default NLO PDF weight is 0\nIncoming particle id and pz:";
+          edm::LogWarning warning("ZeroWeight");
+          warning << "default NLO PDF weight is 0\nIncoming particle id and pz:";
           for (const auto& p : particleList)
             if (p->genStatus == -1)
-              *warning << "\n" << p->id << " " << p->z();
+              warning << "\n" << p->id << " " << p->z();
           break;
         }
 

--- a/AnalysisStep/src/LHEHandler.cc
+++ b/AnalysisStep/src/LHEHandler.cc
@@ -59,12 +59,16 @@ void LHEHandler::clear(){
   PDFid.clear();
   PDFScale=0;
   LHEOriginalWeight=1;
+  powhegOriginalWeight=1;
   defaultNLOweight=1;
 }
 
 MELACandidate* LHEHandler::getBestCandidate(){ return genCand; }
 float const& LHEHandler::getLHEOriginalWeight() const{
   return this->LHEOriginalWeight;
+}
+float const& LHEHandler::getPowhegOriginalWeight() const{
+  return this->powhegOriginalWeight;
 }
 float LHEHandler::getLHEWeight(unsigned int whichWeight, float defaultValue) const{
   if (whichWeight<LHEWeight.size()) return LHEWeight.at(whichWeight);
@@ -83,7 +87,7 @@ float LHEHandler::getLHEWeigh_AsMZUpDn(int whichUpDn, float defaultValue) const{
 float const& LHEHandler::getPDFScale() const{ return PDFScale; }
 float LHEHandler::reweightNNLOtoNLO() const{
   if (year == 2017)
-    return defaultNLOweight / getLHEWeight(0, 1);
+    return defaultNLOweight; //note this is already divided by originalPowhegWeight
   throw cms::Exception("LHEWeights") << "Shouldn't be calling this function for " << year;
 }
 
@@ -186,6 +190,17 @@ void LHEHandler::readEvent(){
   vector<float> LHEPDFAlphaSMZWgt;
   vector<float> LHEPDFVariationWgt;
   bool founddefaultNLOweight = false;
+  bool foundpowhegOriginalWeight = false;
+  powhegOriginalWeight = LHEOriginalWeight;
+  //first find the main powheg weight (should be one of the first)
+  for (const auto& weight : (*lhe_evt)->weights()) {
+    if (weight.id == "1001") {
+      powhegOriginalWeight = weight.wgt;
+      foundpowhegOriginalWeight = true;
+      break;
+    }
+  }
+
   for (const auto& weight : (*lhe_evt)->weights()) {
     int wgtid;
     try {
@@ -193,7 +208,7 @@ void LHEHandler::readEvent(){
     } catch (std::invalid_argument& e) {
       continue;  //we don't use non-numerical indices, but they exist in some 2016 MC samples
     }
-    float wgtval=weight.wgt / LHEOriginalWeight;
+    float wgtval=weight.wgt / powhegOriginalWeight;
     //cout << "PDF id = " << PDFid.at(0) << " " << wgtid << " -> " << wgtval << endl;
     if (year == 2016) {
       if (wgtid<2000) LHEWeight.push_back(wgtval);
@@ -212,12 +227,12 @@ void LHEHandler::readEvent(){
     }
   }
 
-  if (year == 2017 && !(*lhe_evt)->weights().empty() && !(founddefaultNLOweight && LHEWeight.size() == 9 && LHEPDFVariationWgt.size() == 102)) {
+  if (year == 2017 && !(*lhe_evt)->weights().empty() && !(foundpowhegOriginalWeight && founddefaultNLOweight && LHEWeight.size() == 9 && LHEPDFVariationWgt.size() == 102)) {
     throw cms::Exception("LHEWeights")
             << "For 2017 MC, expect to find either\n"
             << " - no alternate LHE weights, or\n"
             << " - all of the following:\n"
-            << "   - muR and muF variations (1001-1009, found " << LHEWeight.size() << " of them)\n"
+            << "   - muR and muF variations (1001-1009, found " << LHEWeight.size() << " of them, " << (foundpowhegOriginalWeight ? "" : "not ") << "including 1001)\n"
             << "   - the default NLO PDF weight (3000, " << (founddefaultNLOweight ? "found" : "didn't find") << " it)\n"
             << "   - NLO PDF weight variations (3001-3102, found " << LHEPDFVariationWgt.size() << " of them)";
   }

--- a/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
+++ b/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
@@ -246,6 +246,7 @@ namespace {
   std::vector<short> LHEAssociatedParticleId;
 
   Float_t LHEPDFScale = 0;
+  Float_t LHEweight_POWHEGonly = 0;
   Float_t LHEweight_QCDscale_muR1_muF1  = 0;
   Float_t LHEweight_QCDscale_muR1_muF2  = 0;
   Float_t LHEweight_QCDscale_muR1_muF0p5  = 0;
@@ -1251,6 +1252,7 @@ void HZZ4lNtupleMaker::FillLHECandidate(){
   LHEAssociatedParticleId.clear();
 
   LHEPDFScale = 0;
+  LHEweight_POWHEGonly = 0;
   LHEweight_QCDscale_muR1_muF1=0;
   LHEweight_QCDscale_muR1_muF2=0;
   LHEweight_QCDscale_muR1_muF0p5=0;
@@ -1359,6 +1361,7 @@ void HZZ4lNtupleMaker::FillLHECandidate(){
     genHEPMCweight *= lheHandler->reweightNNLOtoNLO();
   }
 
+  LHEweight_POWHEGonly = lheHandler->getPowhegOriginalWeight();
   LHEweight_QCDscale_muR1_muF1 = lheHandler->getLHEWeight(0, 1.);
   LHEweight_QCDscale_muR1_muF2 = lheHandler->getLHEWeight(1, 1.);
   LHEweight_QCDscale_muR1_muF0p5 = lheHandler->getLHEWeight(2, 1.);
@@ -2282,6 +2285,7 @@ void HZZ4lNtupleMaker::BookAllBranches(){
     }
 
     myTree->Book("LHEPDFScale", LHEPDFScale, failedTreeLevel >= minimalFailedTree);
+    myTree->Book("LHEweight_POWHEGonly", LHEweight_POWHEGonly, failedTreeLevel >= minimalFailedTree);
     myTree->Book("LHEweight_QCDscale_muR1_muF1", LHEweight_QCDscale_muR1_muF1, failedTreeLevel >= minimalFailedTree);
     myTree->Book("LHEweight_QCDscale_muR1_muF2", LHEweight_QCDscale_muR1_muF2, failedTreeLevel >= minimalFailedTree);
     myTree->Book("LHEweight_QCDscale_muR1_muF0p5", LHEweight_QCDscale_muR1_muF0p5, failedTreeLevel >= minimalFailedTree);


### PR DESCRIPTION
- systematics are now normalized so that the weight for the variation is `genHEPMCweight * LHEweight_<systematic>`, rather than `genHEPMCweight * LHEweight_<systematic> / LHEweight_QCDscale_muR1_muF1`
- `LHEweight_QCDscale_muR1_muF1` is always 1, but kept for compatibility, so you can still use the old formula
- `LHEweight_POWHEGonly` stores the weight from POWHEG before any JHUGen correction.  It's the same as `genHEPMCweight_NNLO` except in high mass samples, where `genHEPMCweight_NNLO` includes the weight from JHUGen.