### PR TITLE
Typo fix in fixEE2017Params

### DIFF
--- a/AnalysisStep/test/MasterPy/ZZ4lAnalysis.py
+++ b/AnalysisStep/test/MasterPy/ZZ4lAnalysis.py
@@ -1567,7 +1567,7 @@ if (RECORRECTMET and SAMPLE_TYPE == 2017):
     runMetCorAndUncFromMiniAOD(process,
                                isData=(not IsMC),
                                fixEE2017 = True,
-                               fixEE2017Params = {'userawPt': True, 'PtThreshold':50.0, 'MinEtaThreshold':2.65, 'MaxEtaThreshold': 3.139} ,
+                               fixEE2017Params = {'userawPt': True, 'ptThreshold':50.0, 'minEtaThreshold':2.65, 'maxEtaThreshold': 3.139} ,
                                postfix = "ModifiedMET"
                                )
     metTag = cms.InputTag("slimmedMETsModifiedMET","","ZZ")


### PR DESCRIPTION
The parameters should begin with a lower case letter to match with the definitions in PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py.