### PR TITLE
Update LHEHandler version to v1.2.2

### DIFF
--- a/checkout_10X.csh
+++ b/checkout_10X.csh
@@ -32,7 +32,7 @@ git clone https://github.com/usarica/MelaAnalytics.git
 
 #Common LHE tools
 git clone https://github.com/usarica/CommonLHETools.git
-(cd CommonLHETools; git checkout -b from-v121 v1.2.1)
+(cd CommonLHETools; git checkout -b from-v122 v1.2.2)
 
 #MELA
 git clone https://github.com/cms-analysis/HiggsAnalysis-ZZMatrixElement.git ZZMatrixElement

--- a/checkout_80X.csh
+++ b/checkout_80X.csh
@@ -49,7 +49,7 @@ git clone https://github.com/usarica/MelaAnalytics.git
 
 #Common LHE tools
 git clone https://github.com/usarica/CommonLHETools.git
-(cd CommonLHETools; git checkout -b from-v121 v1.2.1)
+(cd CommonLHETools; git checkout -b from-v122 v1.2.2)
 
 #MELA
 git clone https://github.com/cms-analysis/HiggsAnalysis-ZZMatrixElement.git ZZMatrixElement

--- a/checkout_9X.csh
+++ b/checkout_9X.csh
@@ -57,7 +57,7 @@ git clone https://github.com/usarica/MelaAnalytics.git
 
 #Common LHE tools
 git clone https://github.com/usarica/CommonLHETools.git
-(cd CommonLHETools; git checkout -b from-v121 v1.2.1)
+(cd CommonLHETools; git checkout -b from-v122 v1.2.2)
 
 #MELA
 git clone https://github.com/cms-analysis/HiggsAnalysis-ZZMatrixElement.git ZZMatrixElement


### PR DESCRIPTION
- Addresses an additional exception in the WZTo3LNu_3Jets_MLL-50_TuneCP5_13TeV-madgraphMLM-pythia8
- Bugfixes the treatment of WWZ_4F_TuneCP5_13TeV-amcatnlo-pythia8: You need to re-run this sample in '17 and '18 if you have done so and would like to get the correct PDF variations.