### PR TITLE
Fix: scram does not support running shell commands any longer. 

### DIFF
--- a/AnalysisStep/BuildFile.xml
+++ b/AnalysisStep/BuildFile.xml
@@ -19,8 +19,8 @@
 <use name="CommonLHETools/LHEHandler"/>
 
 <!-- Damn syntax! -->
-<Flags CPPDEFINES="CMSSW_VERSION=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_//g -e s/patch\.//)"/>
-<Flags CPPDEFINES="CMSSW_VERSION_MAJOR=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_.*//g)"/>
+<!--Flags CPPDEFINES="CMSSW_VERSION=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_//g -e s/patch\.//)"/-->
+<!--Flags CPPDEFINES="CMSSW_VERSION_MAJOR=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_.*//g)"/-->
 <flags CPPFLAGS="-I$(CMSSW_BASE)/src/JHUGenMELA/MELA/interface/" />
 <!--Flags CXXFLAGS="-Wno-delete-non-virtual-dtor -Wno-error=unused-but-set-variable -Wno-error=unused-variable"/--> 
 

--- a/AnalysisStep/interface/Comparators.h
+++ b/AnalysisStep/interface/Comparators.h
@@ -31,6 +31,8 @@ namespace Comparators {
       theType(type)
     {}
 
+    virtual ~BestCandComparator() = default;
+
     // Helper function, implements the "legacy" Z1/Z2 selection logic
     bool bestZ1bestZ2(const pat::CompositeCandidate& cand_i, const pat::CompositeCandidate& cand_j){
 

--- a/AnalysisStep/plugins/BuildFile.xml
+++ b/AnalysisStep/plugins/BuildFile.xml
@@ -18,8 +18,8 @@
 <use name="MuonMVAReader/Reader"/>
 
 <library   file="*.cc" name="ZZAnalysisAnalysisStepPlugins">
-<Flags CPPDEFINES="CMSSW_VERSION=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_//g -e s/patch\.//)"/>
-<Flags CPPDEFINES="CMSSW_VERSION_MAJOR=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_.*//g)"/>
+<!--Flags CPPDEFINES="CMSSW_VERSION=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_//g -e s/patch\.//)"/-->
+<!--Flags CPPDEFINES="CMSSW_VERSION_MAJOR=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_.*//g)"/-->
 <flags CPPFLAGS="-I$(CMSSW_BASE)/src/JHUGenMELA/MELA/interface/" />
 <flags   EDM_PLUGIN="1"/>
 </library>

--- a/AnalysisStep/plugins/Philler.cc
+++ b/AnalysisStep/plugins/Philler.cc
@@ -192,11 +192,12 @@ Philler::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
    if(l.gsfTrack().isNonnull() && l.gsfTrack().isAvailable())
 	  {
-		#if CMSSW_VERSION_MAJOR < 9
-	   l.gsfTrack()->hitPattern().numberOfHits(HitPattern::MISSING_INNER_HITS);
-		#else
-	   l.gsfTrack()->hitPattern().numberOfAllHits(HitPattern::MISSING_INNER_HITS);
-		#endif
+// This is no longer supported.
+//		#if CMSSW_VERSION_MAJOR < 9 
+//	   l.gsfTrack()->hitPattern().numberOfHits(HitPattern::MISSING_INNER_HITS);
+// 		#else
+ 	   l.gsfTrack()->hitPattern().numberOfAllHits(HitPattern::MISSING_INNER_HITS);
+// 		#endif
 	  }
 	  
     //-- Flag for crack photons (which use different efficiency SFs)

--- a/AnalysisStep/src/CompositeCandMassResolution.cc
+++ b/AnalysisStep/src/CompositeCandMassResolution.cc
@@ -108,12 +108,7 @@ void CompositeCandMassResolution::fillP3Covariance(const reco::Candidate &c, TMa
 }
 
 void CompositeCandMassResolution::fillP3Covariance(const reco::Muon &c, TMatrixDSym &bigCov, int offset) const {
-#if CMSSW_VERSION>500
     fillP3Covariance(c, *c.muonBestTrack(), bigCov, offset);
-#else
-    // FIXME: what should be done in this case? Probably we should search for the track with a pT matching the "default" muon pT among innerTrack() and globalTrack().
-    fillP3Covariance(c, *c.track(), bigCov, offset);
-#endif
 }
 
 

--- a/AnalysisStep/src/ZZMassErrors.cc
+++ b/AnalysisStep/src/ZZMassErrors.cc
@@ -31,11 +31,7 @@ namespace {
   float simpleParameterizationUncertainty(const pat::Electron* electron) {
     float error = 999. ;
 
-#if CMSSW_VERSION<500
-    double ecalEnergy = electron->ecalEnergy() ;
-#else
     double ecalEnergy = electron->correctedEcalEnergy() ;
-#endif
 
     if (electron->isEB()) {
       float parEB[3] = { 5.24e-02,  2.01e-01, 1.00e-02} ;

--- a/AnalysisStep/test/BuildFile.xml
+++ b/AnalysisStep/test/BuildFile.xml
@@ -26,8 +26,8 @@
 <use name="rootrflx"/>
 <use name="roofitcore"/>
 
-<Flags CPPDEFINES="CMSSW_VERSION=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_//g -e s/patch\.//)"/>
-<Flags CPPDEFINES="CMSSW_VERSION_MAJOR=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_.*//g)"/>
+<!--Flags CPPDEFINES="CMSSW_VERSION=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_//g -e s/patch\.//)"/-->
+<!--Flags CPPDEFINES="CMSSW_VERSION_MAJOR=$(shell echo ${CMSSW_VERSION}|sed -e s/CMSSW_// -e s/_.*//g)"/-->
 <flags CPPFLAGS="-I$(CMSSW_BASE)/src/JHUGenMELA/MELA/interface/" />
 
 <library   file="*.cc" name="ZZAnalysisAnalysisStepTest">

--- a/checkout_10X.csh
+++ b/checkout_10X.csh
@@ -52,13 +52,20 @@ git clone https://github.com/bonanomi/MuonMVAReader.git MuonMVAReader
 git clone https://github.com/MELALabs/MelaAnalytics.git
 
 #Common LHE tools
-#git clone https://github.com/acappati/CommonLHETools.git
-git clone https://github.com/usarica/CommonLHETools.git
-(cd CommonLHETools; git checkout -b from-v134 v1.3.4)
+#git clone https://github.com/usarica/CommonLHETools.git
+#(cd CommonLHETools; git checkout -b from-v134 v1.3.4)
+#--->Hack for scram update preventing shell scripts in BuildFiles
+git clone https://github.com/namapane/CommonLHETools.git
+(cd CommonLHETools; git checkout v134-fixScram)
+
 
 #MELA
-git clone https://github.com/JHUGen/JHUGenMELA.git JHUGenMELA
-(cd JHUGenMELA; git checkout -b from-v231 v2.3.1)
+#git clone https://github.com/JHUGen/JHUGenMELA.git JHUGenMELA
+#(cd JHUGenMELA; git checkout -b from-v231 v2.3.1)
+#--->Hack for scram update preventing shell scripts in BuildFiles
+git clone https://github.com/namapane/JHUGenMELA.git JHUGenMELA
+(cd JHUGenMELA; git checkout v231-fixScram)
+
 # replace JHUGenMELA/MELA/setup.sh -j 8
 (                                                                 \
   cd ${CMSSW_BASE}/src/JHUGenMELA/MELA/COLLIER/                  ;\
@@ -86,6 +93,9 @@ git clone https://github.com/JHUGen/JHUGenMELA.git JHUGenMELA
   cd ${CMSSW_BASE}/src/JHUGenMELA/MELA/                          ;\
   ./downloadNNPDF.sh                                             ;\
 )
+
+#download MCFM lib (cannot be done in BuildFile.xml any longer)
+$CMSSW_BASE/src/JHUGenMELA/MELA/data/retrieve.csh $SCRAM_ARCH mcfm_707
 
 #kinematic refitting
 git clone https://github.com/mhl0116/KinZfitter-1.git KinZfitter


### PR DESCRIPTION
Temporary switch to forks for JHUGenMELA and CommonLHETools for the same reason, while they are fixed upstream.