### PR TITLE
Fix bug in calling LHEHandler

### DIFF
--- a/AnalysisStep/scripts/cleanup.csh
+++ b/AnalysisStep/scripts/cleanup.csh
@@ -1,7 +1,7 @@
 #!/bin/tcsh
 
 set nonomatch
-set list = ( */*.root */*.corrupted */*.recovered */*.gz */*.txt */core* */jobid  */LSFJOB*/ */log/* */output/* */error/*)
+set list = ( */*.root */*.corrupted */*.recovered */*.gz */*.txt */core* */jobid  */LSFJOB*/ */log/* */output/* */error/* */*.DAT */*.cc)
 
 foreach f ( ${list} )
     if ( -e $f ) then

--- a/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
+++ b/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
@@ -770,6 +770,7 @@ private:
   TGraphErrors *gr_NNLOPSratio_pt_powheg_3jet;
 
   bool printedLHEweightwarning;
+  bool firstRun;
 };
 
 //
@@ -809,7 +810,8 @@ HZZ4lNtupleMaker::HZZ4lNtupleMaker(const edm::ParameterSet& pset) :
   dataTag(pset.getParameter<string>("dataTag")),
   h_weight(0),
 
-  printedLHEweightwarning(false)
+  printedLHEweightwarning(false),
+  firstRun(true)
 {
   //cout<< "Beginning Constructor\n\n\n" <<endl;
   consumesMany<std::vector< PileupSummaryInfo > >();
@@ -2621,7 +2623,6 @@ void HZZ4lNtupleMaker::endJob()
 // ------------ method called when starting to processes a run  ------------
 void HZZ4lNtupleMaker::beginRun(edm::Run const& iRun, edm::EventSetup const&)
 {
-  static bool firstRun=true;
   if (firstRun){
     if (lheHandler){
       edm::Handle<LHERunInfoProduct> lhe_runinfo;


### PR DESCRIPTION
Resolve a subtle bug in calling LHEHandler:

the initialization variable "firstRun" in HZZ4lNtupleMaker was a static in local scope. However, we have different instances of HZZ4lNtupleMaker for the SR and for CRs. Given that the static is shared among all instances, `lheHandler->setHeaderFromRunInfo(&lhe_runinfo);` was callled only for one of the instances, and not for the others.

**Side effects:**
- For some special UL samples (VVV, DYJets), that are labelled as specialPDF_NNPDF31_NNLO_as_0118_Madgraph_1000offset_Case2 by LHEHandler, the missing initialization leads to an unexpected condition and crash;
- For other samples, the missing initialization means that LHEHandler may be fooled in interpreting the type of sample and this can possibly affect how it computes alternate weights.


