### PR TITLE
Allow option to hadd directly to a destination folder

### DIFF
--- a/AnalysisStep/python/hadd.py
+++ b/AnalysisStep/python/hadd.py
@@ -77,7 +77,9 @@ def haddRec(odir, idirs):
         for file in files:
             hadd('/'.join([root, file]), odir, idirs)
 
-def haddChunks(idir, removeDestDir, cleanUp=False):
+def haddChunks(idir, removeDestDir, cleanUp=False, destdir=None ):
+    if destdir == None : destdir = idir
+        
     chunks = {}
     for file in sorted(os.listdir(idir)):
         filepath = '/'.join( [idir, file] )
@@ -95,7 +97,7 @@ def haddChunks(idir, removeDestDir, cleanUp=False):
         print 'warning: no chunk found.'
         return
     for i, (comp, cchunks) in enumerate(chunks.iteritems(), start=1):
-        odir = '/'.join( [idir, comp] )
+        odir = '/'.join( [destdir, comp] )
         print
         print "======================"
         print "hadding folder", i, "/", len(chunks)

--- a/AnalysisStep/scripts/haddChunks.py
+++ b/AnalysisStep/scripts/haddChunks.py
@@ -23,8 +23,16 @@ if __name__ == '__main__':
     parser.add_option("-c","--clean", dest="clean",
                       default=False,action="store_true",
                       help="move chunks to Chunks/ after processing.")
+    parser.add_option("-d","--destdir", dest="destdir",
+                      default=None,
+                      help="write to a destination directpory")
 
     (options,args) = parser.parse_args()
+
+    if options.destdir != None:
+        import click
+        if not click.confirm('Output will be written to '+options.destdir+'\nDo you want to continue?', default=True) :
+            sys.exit(0)
 
     if len(args)!=1:
         print 'provide exactly one directory in argument.'
@@ -32,5 +40,8 @@ if __name__ == '__main__':
 
     dir = args[0]
 
-    haddChunks(dir, options.remove, options.clean)
+
+
+
+    haddChunks(dir, options.remove, options.clean, options.destdir)
 


### PR DESCRIPTION
new option -d in haddChunks to specify a destination directory, so that it is possible to hadd directly to the final eos area, saving a copy operation.

Default behaviour is unchanged (ie hadd to the same folder where chunks reside)