### PR TITLE
FSR fixes

### DIFF
--- a/AnalysisStep/plugins/LeptonPhotonMatcher.cc
+++ b/AnalysisStep/plugins/LeptonPhotonMatcher.cc
@@ -181,22 +181,26 @@ LeptonPhotonMatcher::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       double dRMin(10e9);
       const reco::Candidate* closestLep = 0;
 
-      // Loop over pat::Muon
-      for (unsigned int j = 0; j< muonHandle->size(); ++j){
-        //      const pat::Muon* m = ((*muonHandle)[j]).get();
-        const pat::Muon* m = &((*muonHandle)[j]);
-        if (! m->userFloat("isSIP")) continue;
-        double dR = ROOT::Math::VectorUtil::DeltaR(m->momentum(),g->momentum());
-        if(debug) cout << "muon pt = " << m->pt() << " photon pt = " << g->pt() << " dR = " << dR << endl;
-        if (dR>0.5) continue;
-        if (dR<dRMin) {
-          dRMin = dR;
-          closestLep = m;
-        }
-      }//end loop over muon collection
-
       //---------------------
-      // Loop over pat::Electron
+      // Loop over pat::Muon. We consider only photons in the muon eta range (|eta|<2.4)
+      //---------------------
+      if (fabs(g->eta())<2.4) {
+        for (unsigned int j = 0; j< muonHandle->size(); ++j){
+          //      const pat::Muon* m = ((*muonHandle)[j]).get();
+          const pat::Muon* m = &((*muonHandle)[j]);
+          if (! m->userFloat("isSIP")) continue;
+          double dR = ROOT::Math::VectorUtil::DeltaR(m->momentum(),g->momentum());
+          if(debug) cout << "muon pt = " << m->pt() << " photon pt = " << g->pt() << " dR = " << dR << endl;
+          if (dR>0.5) continue;
+          if (dR<dRMin) {
+            dRMin = dR;
+            closestLep = m;
+          }
+        }//end loop over muon collection
+      }
+      
+      //---------------------
+      // Loop over pat::Electron (keeping all preselected photons up to |eta|<2.5)
       //---------------------
       for (unsigned int j = 0; j< electronHandle->size(); ++j){
         //      const pat::Electron* e = ((*electronHandle)[j]).get();

--- a/AnalysisStep/plugins/PhotonFiller.cc
+++ b/AnalysisStep/plugins/PhotonFiller.cc
@@ -114,8 +114,8 @@ PhotonFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       // We only want photons
       if (g->pdgId()!=22) continue;
 
-      // Photon preselection (is currently already applied on pat::PackedCandidate collection)
-      if (!(g->pt()>2. && fabs(g->eta())<2.4)) continue;
+      // Photon preselection
+      if (!(g->pt()>2. && fabs(g->eta())<2.5)) continue;
 
       //---------------------
       // // Supercluster veto
@@ -125,28 +125,17 @@ PhotonFiller::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       if (electronHandle->size()>0) {
         for (unsigned int j = 0; j< electronHandle->size(); ++j){
           const pat::Electron* e = &((*electronHandle)[j]);
-          if (e->userFloat("isSIP")){
-            if (setup>=2016) {
-              if ((e->associatedPackedPFCandidates()).size()) {
-    	        edm::RefVector < pat::PackedCandidateCollection > pfcands = e->associatedPackedPFCandidates();
-    	        for ( auto itr: pfcands ) {
-                  if (g.get()==&(*itr)) {
-      	            SCVeto=true; 
-      	            if (debug) cout << "SC veto: " << itr->eta() << " " << itr->phi() << "   " 
-      	                	    << fabs(g->eta() - itr->eta()) << " " << reco::deltaPhi(g->phi(), itr->phi()) <<endl;
-      	            break;
-      	          }  
-                }
-              }
-            } else {
-      	      double dR = reco::deltaR(*(e->superCluster()), *g);
-              if ((fabs(g->eta() - e->superCluster()->eta())<0.05 && fabs(reco::deltaPhi(g->phi(), e->superCluster()->phi()))<2.) || dR<0.15) {
-    	        SCVeto=true;
-    	        if (debug) cout << "SC veto: "<< g->pt() << " " << e->pt() << " " << dR << " "
-    	  		        << fabs(g->eta() - e->superCluster()->eta()) << " " << reco::deltaPhi(g->phi(), e->superCluster()->phi()) <<endl;
-    	        break;
-    	      } 
-    	    }
+//          if (! e->userFloat("isSIP")) continue; // uncomment to skip non-prompt electrons from veto (as done up to HIG-19-001)
+	  if ((e->associatedPackedPFCandidates()).size()) {
+	    edm::RefVector < pat::PackedCandidateCollection > pfcands = e->associatedPackedPFCandidates();
+	    for ( auto itr: pfcands ) {
+	      if (g.get()==&(*itr)) {
+		SCVeto=true; 
+		if (debug) cout << "SC veto: " << itr->eta() << " " << itr->phi() << "   " 
+				<< fabs(g->eta() - itr->eta()) << " " << reco::deltaPhi(g->phi(), itr->phi()) <<endl;
+		break;
+	      }
+	    }
     	  }  
         }
       }

--- a/AnalysisStep/test/MasterPy/ZZ4lAnalysis.py
+++ b/AnalysisStep/test/MasterPy/ZZ4lAnalysis.py
@@ -604,7 +604,7 @@ if(IsMC):
 
 # Create a photon collection; cfg extracted from "UFHZZAnalysisRun2.FSRPhotons.fsrPhotons_cff"
 process.fsrPhotons = cms.EDProducer("PhotonFiller",
-    electronSrc = cms.InputTag("cleanSoftElectrons"),
+    electronSrc = cms.InputTag("slimmedElectrons"),
     sampleType = cms.int32(SAMPLE_TYPE),
     setup = cms.int32(LEPTON_SETUP), # define the set of effective areas, rho corrections, etc.
     photonSel = cms.string(FSRMODE)  # "skip", "passThrough", "RunII"


### PR DESCRIPTION
- Extend FSR to the full electron eta range (|eta_ele|<2.5)
- include all electrons in FSR footprint veto (not just prompt ones)
More details in [this presentation](https://indico.cern.ch/event/1109091/#31-h4l-object-selection-toward).
Effects are tiny; very rare additional FSR for electrons above 2.4<|eta|<2.5, and a very slight suppression of fake FSRs due to extending the footprint veto.