### PR TITLE
Revert bug introduced in the PU reweighting control plots

### DIFF
--- a/AnalysisStep/test/Ntuplizers/ZZ4lAnalyzer.cc
+++ b/AnalysisStep/test/Ntuplizers/ZZ4lAnalyzer.cc
@@ -473,12 +473,13 @@ void ZZ4lAnalyzer::analyze(const Event & event, const EventSetup& eventSetup){
 
     PUweight = pileUpReweight->weight(nTrueInt);
 
+    // These plots are intended to cross-check the PU reweighting procedure, 
+    // by comparison of the PU-reweighted and original distributions.
     hNvtxWeight->Fill(Nvtx,PUweight);
-    hNTrueIntWeight->Fill(nTrueInt,genHEPMCweight);
+    hNTrueIntWeight->Fill(nTrueInt,PUweight);
     hRhoWeight->Fill(*rhoHandle,PUweight);
 
   }
-
   hNvtxNoWeight->Fill(Nvtx);
   hNTrueIntNoWeight->Fill(nTrueInt);
   hRhoNoWeight->Fill(*rhoHandle);


### PR DESCRIPTION
These plots are used to check the correctness of the PU reweighting; they have nothing to do with gen MC weight.