### PR TITLE
[OSmethod.cpp] missing ISO check for muons

### DIFF
--- a/AnalysisStep/test/ZpXEstimation/src/OSmethod.cpp
+++ b/AnalysisStep/test/ZpXEstimation/src/OSmethod.cpp
@@ -377,7 +377,7 @@ void OSmethod::MakeHistogramsZX( TString input_file_data_name, TString  input_fi
       if ( test_bit(CRflag, CRZLLos_3P1F) )
       {
 	//nevents_CRLLos_3P1F += 1;
-	if(LepisID->at(3))
+	if(LepisID->at(3) && ((fabs(LepLepId->at(3)) == 11) ? LepCombRelIsoPF->at(3) < 999999. : LepCombRelIsoPF->at(3) < 0.35))
 	  {
 	    _f4    = FR->GetFakeRate(LepPt->at(2),LepEta->at(2),LepLepId->at(2));
 	    _f4_Up = FR->GetFakeRate_Up(LepPt->at(2),LepEta->at(2),LepLepId->at(2));
@@ -480,7 +480,7 @@ void OSmethod::MakeZXMCContribution( TString input_file_data_name, TString  inpu
       _k_factor = calculate_K_factor(input_file_data_name);
       _event_weight = (_lumi * 1000 * xsec * _k_factor * overallEventWeight * L1prefiringWeight) / gen_sum_weights;
       
-      if( LepisID->at(3) )
+      if( LepisID->at(3) && ((fabs(LepLepId->at(3)) == 11) ? LepCombRelIsoPF->at(3) < 999999. : LepCombRelIsoPF->at(3) < 0.35))
       {
 	_f4    = FR->GetFakeRate(LepPt->at(2),LepEta->at(2),LepLepId->at(2));
 	_f4_Up = FR->GetFakeRate_Up(LepPt->at(2),LepEta->at(2),LepLepId->at(2));


### PR DESCRIPTION
Found a bug in the ZX code. 
The ISO check was missing. This change has an effect only for muons, for electrons ISO is included in the BDT used for ID.
In the pictures you can see the comparison for ZX before and after the bug fixing. 

![image_2022_09_22T15_12_51_194Z](https://user-images.githubusercontent.com/44396252/194510528-5a813a93-7985-4e53-95bb-7941eb0181ae.png)
![image_2022_09_22T15_10_13_434Z](https://user-images.githubusercontent.com/44396252/194510534-7354de5b-5446-4f91-942c-5a4049b6d145.png)
