### PR TITLE
Re-set candidate choice to byBestKD

### DIFF
--- a/AnalysisStep/test/MasterPy/ZZ4lAnalysis.py
+++ b/AnalysisStep/test/MasterPy/ZZ4lAnalysis.py
@@ -49,8 +49,7 @@ declareDefault("SUPERMELA_MASS", 125, globals())
 declareDefault("SELSETUP", "allCutsAtOncePlusSmart", globals())
 
 #Best candidate comparator (see interface/Comparators.h)
-declareDefault("BESTCANDCOMPARATOR", "byBestZ1bestZ2", globals()) #ATbbf
-# declareDefault("BESTCANDCOMPARATOR", "byBestKD", globals()) #ATbbf
+declareDefault("BESTCANDCOMPARATOR", "byBestKD", globals())
 
 # Set to True to make candidates with the full combinatorial of loose leptons (for debug; much slower)
 declareDefault("KEEPLOOSECOMB", False, globals())


### PR DESCRIPTION
...which was set to byBestZ1bestZ2 in Run2_CutBased_UL, since that branch is used for the differential analysis.

**PLEASE DO NOT MERGE THIS PR UNTIL THE CURRENT ROUND OF PRODUCTION IS OVER**