### PR TITLE
Add option to transfer output to /eos/user instead of copying it back to AFS

### DIFF
--- a/AnalysisStep/scripts/batch_Condor.py
+++ b/AnalysisStep/scripts/batch_Condor.py
@@ -1,4 +1,5 @@
 #!/bin/env python
+from __future__ import print_function
 
 import sys
 import imp
@@ -41,26 +42,19 @@ def split(comps):
         else:
             numJobs=1
             splitComps.append( comp )
-        print comp.name, ": files=", len(comp.files), ' chunkSize=', chunkSize, "jobs=", numJobs
+        print(comp.name, ": files=", len(comp.files), ' chunkSize=', chunkSize, "jobs=", numJobs)
     return splitComps
 
 
 def batchScript( index, remoteDir=''):
    '''prepare the Condor version of the batch script, to run on HTCondor'''
-#   print "INDEX", index
-#   print "remotedir", remoteDir
+#Note: ${VAR} in the script have to be escaped as ${{VAR}}
+# as the string is parsed through .format
    script = """#!/bin/bash
 set -euo pipefail
 
-if [ -z ${_CONDOR_SCRATCH_DIR+x} ]; then
-  #running locally
-  runninglocally=true
-  _CONDOR_SCRATCH_DIR=$(mktemp -d)
-  SUBMIT_DIR=$(pwd)
-else
-  runninglocally=false
-  SUBMIT_DIR=$1
-fi
+SUBMIT_DIR=$1
+TRANSFER_DIR={remoteDir}
 
 cd $SUBMIT_DIR
 eval $(scram ru -sh)
@@ -69,18 +63,19 @@ cp run_cfg.py $_CONDOR_SCRATCH_DIR
 cd $_CONDOR_SCRATCH_DIR
 
 echo 'Running at:' $(date)
+echo SUBMIT_DIR: $SUBMIT_DIR
 echo path: `pwd`
 
 cmsRunStatus=   #default for successful completion is an empty file
 cmsRun run_cfg.py |& grep -v -e 'MINUIT WARNING' -e 'Second derivative zero' -e 'Negative diagonal element' -e 'added to diagonal of error matrix' > log.txt || cmsRunStatus=$?
 
 echo -n $cmsRunStatus > exitStatus.txt
-echo 'cmsRun done at: ' $(date) with exit status: ${cmsRunStatus+0}
+echo 'cmsRun done at: ' $(date) with exit status: ${{cmsRunStatus+0}}
 gzip log.txt
 
 export ROOT_HIST=0
 if [ -s ZZ4lAnalysis.root ]; then
- root -q -b '${CMSSW_BASE}/src/ZZAnalysis/AnalysisStep/test/prod/rootFileIntegrity.r("ZZ4lAnalysis.root")'
+ root -q -b '${{CMSSW_BASE}}/src/ZZAnalysis/AnalysisStep/test/prod/rootFileIntegrity.r("ZZ4lAnalysis.root")'
 else
  echo moving empty file
  mv ZZ4lAnalysis.root ZZ4lAnalysis.root.empty
@@ -98,31 +93,30 @@ rm -f run_cfg.py batchScript.sh
 
 echo '...done at' $(date)
 
-#note cping back is handled automatically by condor
-if $runninglocally; then
-  cp ZZ4lAnalysis.root* *.txt *.gz $SUBMIT_DIR
+# Handle transfer of output to EOS. 
+# As copying back of files is handled automatically by condor, it must be overridden in condor.sub
+# NOTE: using the FUSE interface since eos commands do not appear to work reliably on batch (issues with permissions etc)
+if [ -n "$TRANSFER_DIR" ] ; then
+    p1=`dirname $SUBMIT_DIR`
+    p2=`basename $p1`
+    eosOutputPath=$TRANSFER_DIR/$p2/`basename $SUBMIT_DIR`
+    echo "Transferring output to: "$eosOutputPath
+    mkdir -p $eosOutputPath
+    cp ZZ4lAnalysis.root* *.txt *.gz ${{eosOutputPath}}/
+    echo "...done"
 fi
 
 exit $cmsRunStatus
 """ 
-   return script
+   return script.format(remoteDir=remoteDir)
 
 def batchScriptNano( index, remoteDir=''):
    '''prepare the Condor version of the batch script, to run on HTCondor'''
-#   print "INDEX", index
-#   print "remotedir", remoteDir
    script = '''#!/bin/bash
 set -euo pipefail
 
-if [ -z ${_CONDOR_SCRATCH_DIR+x} ]; then
-  #running locally
-  runninglocally=true
-  _CONDOR_SCRATCH_DIR=$(mktemp -d)
-  SUBMIT_DIR=$(pwd)
-else
-  runninglocally=false
-  SUBMIT_DIR=$1
-fi
+SUBMIT_DIR=$1
+TRANSFER_DIR={remoteDir}
 
 cd $SUBMIT_DIR
 eval $(scram ru -sh)
@@ -131,18 +125,19 @@ cp run_cfg.py $_CONDOR_SCRATCH_DIR
 cd $_CONDOR_SCRATCH_DIR
 
 echo 'Running at:' $(date)
+echo SUBMIT_DIR: $SUBMIT_DIR
 echo path: `pwd`
 
 exitStatus=   #default for successful completion is an empty file
 python run_cfg.py >& log.txt || exitStatus=$?
 
 echo -n $exitStatus > exitStatus.txt
-echo 'job done at: ' $(date) with exit status: ${exitStatus+0}
+echo 'job done at: ' $(date) with exit status: ${{exitStatus+0}}
 gzip log.txt
 
 export ROOT_HIST=0
 if [ -s ZZ4lAnalysis.root ]; then
- root -q -b '${CMSSW_BASE}/src/ZZAnalysis/AnalysisStep/test/prod/rootFileIntegrity.r("ZZ4lAnalysis.root")'
+ root -q -b '${{CMSSW_BASE}}/src/ZZAnalysis/AnalysisStep/test/prod/rootFileIntegrity.r("ZZ4lAnalysis.root")'
 else
  echo moving empty file
  mv ZZ4lAnalysis.root ZZ4lAnalysis.root.empty
@@ -162,16 +157,27 @@ rm -f run_cfg.py batchScript.sh
 
 echo '...done at' $(date)
 
-##note cping back is handled automatically by condor
-#if $runninglocally; then
-#  cp ZZ4lAnalysis.root* *.txt *.gz $SUBMIT_DIR
-#fi
+# Handle transfer of output to EOS.
+# As copying back of files is handled automatically by condor, it must be overridden in condor.sub
+# NOTE: using the FUSE interface since eos commands do not appear to work reliably on batch (issues with permissions etc)
+if [ -n "$TRANSFER_DIR" ] ; then
+    p1=`dirname $SUBMIT_DIR`
+    p2=`basename $p1`
+    eosOutputPath=$TRANSFER_DIR/$p2/`basename $SUBMIT_DIR`
+    echo "Transferring output to: "$eosOutputPath
+    mkdir -p $eosOutputPath
+    cp ZZ4lAnalysis.root* *.txt *.gz ${{eosOutputPath}}/
+    echo "...done"
+fi
 
 exit $exitStatus
 '''
-   return script
+   return script.format(remoteDir=remoteDir)
 
-def condorSubScript( index, mainDir ):
+
+# Create the CONDOR submit file (one per submission).
+# transferOutput = False skips the automatic CONDOR transfer of output files to the submission dir
+def condorSubScript( index, mainDir, transferOutput=True) :
    '''prepare the Condor submition script'''
    script = '''
 executable              = $(directory)/batchScript.sh
@@ -181,17 +187,21 @@ error                   = log/$(ClusterId).$(ProcId).err
 log                     = log/$(ClusterId).log
 Initialdir              = $(directory)
 request_memory          = '''+str(batchManager.options_.jobmem)+'''
-#Possible values: https://batchdocs.web.cern.ch/local/submit.html
+#Possible values: longlunch, workday, tomorrow, etc.; cf. https://batchdocs.web.cern.ch/local/submit.html
 +JobFlavour             = "'''+batchManager.options_.jobflavour+'''"
 
 x509userproxy           = {home}/x509up_u{uid}
 
-#https://www-auth.cs.wisc.edu/lists/htcondor-users/2010-September/msg00009.shtml
+#cf. https://www-auth.cs.wisc.edu/lists/htcondor-users/2010-September/msg00009.shtml
 periodic_remove         = JobStatus == 5
 
-ShouldTransferFiles     = NO
+{transfer}
 '''   
-   return script.format(home=os.path.expanduser("~"), uid=os.getuid(), mainDir=mainDir)
+   if transferOutput == True :
+       transfer=''
+   else:
+       transfer='transfer_output_files   = ""'       
+   return script.format(home=os.path.expanduser("~"), uid=os.getuid(), mainDir=mainDir, transfer=transfer)
 
             
 class MyBatchManager:
@@ -236,18 +246,22 @@ class MyBatchManager:
                                 dest="verbose",default =False,
                                 help="Activate verbose output",)
 
+        self.parser_.add_option("-t", "--transfer", dest="transferPath",
+                                default="",
+                                help="full path of /eos/user area to transfer output files, in the respective PROD/Chunk subfolders. Note that log files will still be sent back to the submission folder.",)
+
 
         (self.options_,self.args_) = self.parser_.parse_args()
 
 
         if ( len(self.args_)!=1) :
-            print "Please specify sample.csv file to be used.\n"
+            print("Please specify sample.csv file to be used.\n")
             sys.exit(1)
              
         csvfile = self.args_[0]
 
         if (os.path.exists(csvfile) == False ):
-            print "File", csvfile, "does not exist; please specify a valid one.\n"
+            print("File", csvfile, "does not exist; please specify a valid one.\n")
             sys.exit(1)
 
         # Handle output directory
@@ -257,7 +271,7 @@ class MyBatchManager:
 #             outputDir = 'OutCmsBatch_%s' % today.strftime("%d%h%y_%H%M")
             gitrevision = subprocess.check_output(['git', "rev-parse", "--short", "HEAD"]) #revision of the git area where the command is exectuted
             outputDir = "PROD_" + csvfile.replace('.csv','') + "_"+gitrevision.rstrip()
-            print 'output directory not specified, using %s' % outputDir
+            print('output directory not specified, using %s' % outputDir)
         self.outputDir_ = os.path.abspath(outputDir)
         self.workingDir = str(self.outputDir_)
         if( os.path.isdir(self.outputDir_) == True ):
@@ -269,7 +283,7 @@ class MyBatchManager:
                 sys.exit(1)
             else:
                 os.system( 'rm -rf ' + self.outputDir_)
-        print 'Job folder: %s' % self.outputDir_
+        print('Job folder: %s' % self.outputDir_)
         self.mkdir( self.outputDir_ )
         with open(os.path.join(self.outputDir_, ".gitignore"), "w") as f:
             f.write("**/*\n")
@@ -280,19 +294,26 @@ class MyBatchManager:
         else: 
             self.secondaryInputDir_ = None
 
+        # Handle optional EOS transfer
+        self.eosTransferPath=self.options_.transferPath
+        if self.eosTransferPath!="":
+            #Check that the specified path is legal. Only /eos/user is supported for the time being
+            if not self.eosTransferPath.startswith('/eos/user/'):
+                print('Invalid option ', self.eosTransferPath, ' : only paths on /eos/user/ are supported')
+                sys.exit(4)
 
     def mkdir( self, dirname ):
        mkdir = 'mkdir -p %s' % dirname
        ret = os.system( mkdir )
        if( ret != 0 ):
-         print 'please remove or rename directory: ', dirname
+         print('please remove or rename directory: ', dirname)
          sys.exit(4)
     
     
 
        
     def PrepareJobs(self, listOfValues, listOfDirNames=None):
-        print 'PREPARING JOBS ======== '
+        print('PREPARING JOBS ======== ')
         self.listOfJobs_ = []
 
         if listOfDirNames is None:
@@ -302,20 +323,20 @@ class MyBatchManager:
             for value, name in zip( listOfValues, listOfDirNames):
                 self.PrepareJob( value, name )
         if batchManager.options_.verbose:
-            print "list of jobs:"
+            print("list of jobs:")
             pp = pprint.PrettyPrinter(indent=4)
             pp.pprint( self.listOfJobs_)
 
         condorscriptFileName = os.path.join(self.outputDir_, 'condor.sub')
         with open(condorscriptFileName,'w') as condorscriptFile:
-            condorscriptFile.write(condorSubScript(value, self.outputDir_))
+            condorscriptFile.write(condorSubScript(value, self.outputDir_,(self.eosTransferPath=="")))
 
     def PrepareJob( self, value, dirname=None):
        '''Prepare a job for a given value.
        
        calls PrepareJobUser, which should be overloaded by the user.
        '''
-       print '---PrepareJob N: ', value,  ' name: ', dirname
+       print('---PrepareJob N: ', value,  ' name: ', dirname)
 
        inputType="miniAOD"
        if "NANOAOD" in (splitComponents[value].files)[0] :
@@ -325,13 +346,11 @@ class MyBatchManager:
        if dname  is None:
            dname = 'Job_{value}'.format( value=value )
        jobDir = '/'.join( [self.outputDir_, dname])
-#       print '\t',jobDir 
        self.mkdir( jobDir )
        self.mkdir( jobDir + '/log' )
        self.listOfJobs_.append( jobDir )
        if not self.secondaryInputDir_ == None: self.inputPDFDir_ = '/'.join( [self.secondaryInputDir_, dname])
 
-#       print 'self.outputDir_=',self.outputDir_
        if dirname.endswith('Chunk0'):
            self.PrepareJobUserTemplate( jobDir, value, inputType)
        self.PrepareJobUserFromTemplate(jobDir, value, inputType)
@@ -340,9 +359,9 @@ class MyBatchManager:
         scriptFileName = jobDir+'/batchScript.sh'
         scriptFile = open(scriptFileName,'w')
         if inputType=="miniAOD" :
-            scriptFile.write( batchScript( value ) )
+            scriptFile.write( batchScript( value, self.eosTransferPath ) )
         elif inputType=="nanoAOD":
-            scriptFile.write( batchScriptNano( value ) )            
+            scriptFile.write( batchScriptNano( value, self.eosTransferPath ) )
         scriptFile.close()
         os.system('chmod +x %s' % scriptFileName)
         template_name = splitComponents[value].samplename + 'run_template_cfg.py'
@@ -370,8 +389,6 @@ class MyBatchManager:
  
     def PrepareJobUserTemplate(self, jobDir, value, inputType="miniAOD" ):
        '''Prepare one job. This function is called by the base class.'''
-#       print value
-#       print splitComponents[value]
 
        #prepare the batch script
        scriptFileName = jobDir+'/batchScript.sh'
@@ -388,18 +405,18 @@ class MyBatchManager:
        #else: variables['PD'] = ""
 
        if batchManager.options_.verbose:
-           print 'value ',value
-           print 'scv ',splitComponents[value].name
+           print('value ',value)
+           print('scv ',splitComponents[value].name)
        
        variables['SAMPLENAME'] = splitComponents[value].samplename
        variables['XSEC'] = splitComponents[value].xsec 
        #variables = {'IsMC':IsMC, 'PD':PD, 'MCFILTER':MCFILTER, 'SUPERMELA_MASS':SUPERMELA_MASS, 'SAMPLENAME':SAMPLENAME, 'XSEC':XSEC, 'SKIM_REQUIRED':SKIM_REQUIRED}
 
        template_name = variables['SAMPLENAME'] + 'run_template_cfg.py'
-       print '\tSaving template as %s/%s'%(os.path.basename(self.outputDir_), template_name)
-       print "\tParameters: ", variables
-       print '\tpyFragments: ',splitComponents[value].pyFragments
-#       print 'jobDir=',jobDir
+       print('\tSaving template as %s/%s'%(os.path.basename(self.outputDir_), template_name))
+       print("\tParameters: ", variables)
+       print('\tpyFragments: ',splitComponents[value].pyFragments)
+#       print('jobDir=',jobDir)
 
        cfgFile = open('%s/%s'%(self.outputDir_, template_name),'w')
 
@@ -455,7 +472,7 @@ class Component(object):
     def __init__(self, name, prefix, dataset, pattern, splitFactor, variables, pyFragments, xsec, BR, pdfstep, cfgFileName=""):
         self.name = name
         self.samplename = name
-        print "checking "+self.name
+        print("checking "+self.name)
 
         if prefix=="source.fileNames" : #take the files that are specified in the process.source.fileNames in the input .py
             handle = open(cfgFileName, 'r')
@@ -475,7 +492,7 @@ class Component(object):
         self.xsec = float(xsec)*float(BR)
         self.pdfstep = int(pdfstep)
         if self.pdfstep <0 or self.pdfstep>2:
-            print "Unknown PDF step", pdfstep
+            print("Unknown PDF step", pdfstep)
             sys.exit(1)
         
         

--- a/AnalysisStep/test/MasterPy/ZZ4lAnalysis.py
+++ b/AnalysisStep/test/MasterPy/ZZ4lAnalysis.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 from ZZAnalysis.AnalysisStep.defaults import *
 import os, sys
@@ -72,7 +73,7 @@ CMSSW_VERSION = os.environ['CMSSW_VERSION']
 CMSSWVERSION = int(CMSSW_VERSION.split("_")[1])
 
 if SELSETUP=="Legacy" and not BESTCANDCOMPARATOR=="byBestZ1bestZ2":
-    print "WARNING: In ZZ4lAnalysis.py the SELSETUP=\"Legacy\" flag is meant to reproduce the Legacy results, ignoring the setting of the BESTCANDCOMPARATOR: ",BESTCANDCOMPARATOR
+    print("WARNING: In ZZ4lAnalysis.py the SELSETUP=\"Legacy\" flag is meant to reproduce the Legacy results, ignoring the setting of the BESTCANDCOMPARATOR: ",BESTCANDCOMPARATOR)
     BESTCANDCOMPARATOR = "byBestZ1bestZ2"
 
 # The isolation cuts for electrons and muons. FIXME: there is an hardcoded instance of these values in src/LeptonIsoHelper.cc !!
@@ -114,7 +115,7 @@ elif (SAMPLE_TYPE == 2018):
         else:
             process.GlobalTag = GlobalTag(process.GlobalTag, '106X_dataRun2_v35', '')
 
-print '\t',process.GlobalTag.globaltag
+print('\t',process.GlobalTag.globaltag)
 
 
 ### ----------------------------------------------------------------------
@@ -380,7 +381,7 @@ elif LEPTON_SETUP == 2018:# Rochester corrections for 2018 data
 
 else:
     if APPLYMUCORR:
-        print "APPLYMUCORR not configured for LEPTON_SETUP =", LEPTON_SETUP
+        print("APPLYMUCORR not configured for LEPTON_SETUP =", LEPTON_SETUP)
         sys.exit()
 
 
@@ -790,7 +791,7 @@ M4l100            = "mass>100"
 
 
 if SELSETUP=="Legacy": # Default Configuration (Legacy paper): cut on selected best candidate
-    print "SELSETUP=Legacy no longer supported after 8fb591a because we now set combRelIsoPFFSRCorr at the level of ZZ; will need to re-introduce it at  the Z level so that ZZCand.bestZAmong (ie isBestZ flag) works again as before"
+    print("SELSETUP=Legacy no longer supported after 8fb591a because we now set combRelIsoPFFSRCorr at the level of ZZ; will need to re-introduce it at  the Z level so that ZZCand.bestZAmong (ie isBestZ flag) works again as before")
     sys.exit()
     HASBESTZ          = "daughter('Z1').masterClone.userFloat('isBestZ')"
     BESTCAND_AMONG = (FOURGOODLEPTONS + "&&" +
@@ -868,7 +869,7 @@ elif SELSETUP=="allCutsAtOncePlusSmart": # Apply smarter mZb cut
 
 
 else:
-    print "Please choose one of the following string for SELSETUP: 'Legacy', 'allCutsAtOnceButMZ2', 'allCutsAtOnce', 'allCutsAtOncePlusMZb', 'allCutsAtOncePlusSmart'"
+    print("Please choose one of the following string for SELSETUP: 'Legacy', 'allCutsAtOnceButMZ2', 'allCutsAtOnce', 'allCutsAtOncePlusMZb', 'allCutsAtOncePlusSmart'")
     sys.exit()
 
 


### PR DESCRIPTION
This is a backpoport of #162 to Run2UL_22.

New option -t to batch_Condor.py to move output to an /eos/user area to avoid filling the AFS quota.
Notes:
- only /eos/user is accepted for the moment to avoid problems with central areas
- transfer is done with the FUSE mount (plain cp to /eos) as dedicated eos tools appear to work unreliably from batch scripts due to authentication issues.


