### PR TITLE
Use fullID+ISO without SIP for SIP CR. Prepare for 2023 data.

### DIFF
--- a/AnalysisStep/scripts/batch_Condor.py
+++ b/AnalysisStep/scripts/batch_Condor.py
@@ -307,7 +307,7 @@ class MyBatchManager:
                 print('Cannot create transfer directory: ', self.eosTransferPath)
                 sys.exit(4)
             #Create a link to transfer folder
-            ret = os.system('ln -s ' + self.eosTransferPath + " " + self.outputDir_ + "/trasnsferPath")
+            ret = os.system('ln -s ' + self.eosTransferPath + " " + self.outputDir_ + "/transferPath")
             
 
     def mkdir( self, dirname ):

--- a/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
+++ b/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
@@ -2658,10 +2658,13 @@ void HZZ4lNtupleMaker::beginRun(edm::Run const& iRun, edm::EventSetup const&)
     firstRun=false;
   }
 
-  edm::Handle<GenRunInfoProduct> genRunInfo;
-  iRun.getByToken(theGenInfoTokenInRun, genRunInfo);
-  cout << "XSEC from GenRunInfoProduct: "  << genRunInfo->crossSection() << endl;
+  if (isMC){
+    edm::Handle<GenRunInfoProduct> genRunInfo;
+    iRun.getByToken(theGenInfoTokenInRun, genRunInfo);
+    cout << "XSEC from GenRunInfoProduct: "  << genRunInfo->crossSection() << endl;
+  }
 }
+
 
 // ------------ method called when ending the processing of a run  ------------
 void HZZ4lNtupleMaker::endRun(edm::Run const& iRun, edm::EventSetup const&)

--- a/NanoAnalysis/python/tools.py
+++ b/NanoAnalysis/python/tools.py
@@ -1,4 +1,5 @@
 ### Various helper funcions
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
 
 ## handle configuration variables
 _myConf = {}
@@ -28,3 +29,10 @@ def insertAfter(sequence, moduleName, module) :
             sequence.insert(im+1, module)
             return
 
+# Get the four leptons of a ZZ or ZLL candidate
+def getLeptons(aCand, event) :
+    idxs = [aCand.Z1l1Idx, aCand.Z1l2Idx, aCand.Z2l1Idx, aCand.Z2l2Idx]
+    electrons = Collection(event, "Electron")
+    muons = Collection(event, "Muon")
+    leps = list(electrons) + list(muons)
+    return [leps[i] for i in idxs]

--- a/NanoAnalysis/python/triggerAndSkim.py
+++ b/NanoAnalysis/python/triggerAndSkim.py
@@ -18,6 +18,7 @@ class triggerAndSkim(Module):
         self.PD = PD
         self.era = era
         self.passThru = passThru
+        self.debug = False
         print("***INIT triggerAndSkim: IsMC:", self.isMC, "PD:", self.PD, "era:", self.era, "passThru:", passThru)
         
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
@@ -54,8 +55,16 @@ class triggerAndSkim(Module):
             passMuEle = event.HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL or event.HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ or event.HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ or event.HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ or event.HLT_DiMu9_Ele9_CaloIdL_TrackIdL_DZ or event.HLT_Mu8_DiEle12_CaloIdL_TrackIdL_DZ
             passTriEle = False
             passTriMu = event.HLT_TripleMu_10_5_5_DZ or event.HLT_TripleMu_12_10_5
-        elif self.era == 2022 : #FIXME checked these are still unprescaled in run 359751, but should be updated
-            passSingleEle = event.HLT_Ele32_WPTight_Gsf #Note: Ele30 is also unprescaled?
+        elif self.era == 2022 : # Checked that these are unprescaled in run 359751
+            passSingleEle = event.HLT_Ele30_WPTight_Gsf #Note: we used Ele32 in 2018! 
+            passSingleMu = event.HLT_IsoMu24
+            passDiEle = event.HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL or event.HLT_DoubleEle25_CaloIdL_MW
+            passDiMu = event.HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8
+            passMuEle = event.HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL or event.HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ or event.HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ or event.HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ or event.HLT_DiMu9_Ele9_CaloIdL_TrackIdL_DZ or event.HLT_Mu8_DiEle12_CaloIdL_TrackIdL_DZ
+            passTriEle = False
+            passTriMu = event.HLT_TripleMu_10_5_5_DZ or event.HLT_TripleMu_12_10_5
+        elif self.era == 2023 : #FIXME check if some were prescaled
+            passSingleEle = event.HLT_Ele30_WPTight_Gsf or event.HLT_Ele32_WPTight_Gsf #FIXME: Ele30 was still prescaled?
             passSingleMu = event.HLT_IsoMu24
             passDiEle = event.HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL or event.HLT_DoubleEle25_CaloIdL_MW
             passDiMu = event.HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8
@@ -77,8 +86,13 @@ class triggerAndSkim(Module):
                ((PD=="SingleElectron" or PD=="EGamma") and passSingleEle and not passMuEle and not passDiMu and not passTriMu and not passDiEle and not passTriEle) or \
                ((PD=="SingleMuon" or PD=="Muon") and passSingleMu and not passSingleEle and not passMuEle and not passDiMu and not passTriMu and not passDiEle and not passTriEle) :
                    passTrigger = True
-
-
+            
+        if self.debug :
+            print(PD)
+            print((passDiEle or passTriEle))
+            print ((passDiMu or passTriMu) and not passDiEle and not passTriEle)
+            print(passDiEle, passDiMu , passMuEle , passTriEle , passTriMu , passSingleEle , passSingleMu)
+            print(passTrigger)
 
         self.out.fillBranch("HLT_passZZ4lEle", passSingleEle or passDiEle or passTriEle)
         self.out.fillBranch("HLT_passZZ4lMu", passSingleMu or passDiMu or passTriMu)

--- a/NanoAnalysis/test/NanoPlotter/H4l_draw.py
+++ b/NanoAnalysis/test/NanoPlotter/H4l_draw.py
@@ -72,8 +72,8 @@ def getZX(h_model) :
     
 
 ### 2022 plots
-#Lum = 31.3  # 1/fb 2022 C-F 355100_362104 Golden json
-Lum = 35.084 # 1/fb 2022 C-G 355100_362760 Golden json
+#Lum = 35.084 # 1/fb 2022 C-G 355100_362760 Golden json
+Lum = 21.1289 # 1/fb 2022 F-G Golden json (prompt v11)
 
 # Set style matching the one used for HZZ plots
 ROOT.TH1.SetDefaultSumw2()

--- a/NanoAnalysis/test/NanoPlotter/H4l_fill.py
+++ b/NanoAnalysis/test/NanoPlotter/H4l_fill.py
@@ -8,7 +8,7 @@ ROOT.PyConfig.IgnoreCommandLineOptions = True
 
 
 pathMC = "/eos/user/n/namapane/H4lnano/220420/" # FIXME: Use 2018 MC for the time being
-pathDATA = "/eos/user/n/namapane/H4lnano/221130/Data2022/"
+pathDATA = "/eos/user/n/namapane/H4lnano/230506/Data2022/"
 
 ZmassValue = 91.1876
 
@@ -43,6 +43,7 @@ def fillHistos(samplename, filename) :
     events.SetBranchStatus("event", 1)
     events.SetBranchStatus("ZZCand_*", 1)
     events.SetBranchStatus("bestCandIdx", 1)
+    events.SetBranchStatus("HLT_passZZ4l", 1)
     nEntries = events.GetEntries() 
 
     isMC = False
@@ -76,7 +77,10 @@ def fillHistos(samplename, filename) :
         if iEntry%printEntries == 0 : print("Processing", iEntry)
 
         bestCandIdx = events.bestCandIdx
-        if(bestCandIdx != -1):
+        # Check that the event contains a selected candidate, and that
+        # passes the required triggers (which is necessary for samples
+        # processed with TRIGPASSTHROUGH=True)
+        if(bestCandIdx != -1 and events.HLT_passZZ4l): 
             weight = 1.
             if isMC : weight = (events.overallEventWeight*events.ZZCand_dataMCWeight[bestCandIdx])/genEventSumw
             m4l=events.ZZCand_mass[bestCandIdx]
@@ -140,5 +144,5 @@ def runData():
     of.Close()
 
 if __name__ == "__main__" :
-    runMC()
+#    runMC()
     runData()

--- a/NanoAnalysis/test/printCandidates.py
+++ b/NanoAnalysis/test/printCandidates.py
@@ -19,6 +19,7 @@ args = parser.parse_args()
 nanoFile = args.file
 region = args.region
 outputFormat = args.outputFormat
+checkTrigger = True
 
 if region != 'SR' and region != 'SS' and region != '2P2F' and region != '3P1F' and region != 'SIP' :
     print ('Region', region, 'not supported, must be"SR"=signal (default), or CRs: "2P2F", "3P1F", "SS", "SIP"')
@@ -47,7 +48,10 @@ while t.GetEntry(iEntry):
 
     if region == 'SR' :
         iZZ = t.bestCandIdx
-        if iZZ < 0 : continue # no candidate passes selection
+        if iZZ < 0 : continue # no candidate passes selection in this event, or
+            # the event does not pass the required triggers (for samples processed
+            # with TRIGPASSTHROUGH=True)
+        if checkTrigger and not t.HLT_passZZ4l : continue 
         if outputFormat == "eventID" :
             print(eventId)
         else : 

--- a/NanoAnalysis/test/prod/samplesNano_2022_Data.csv
+++ b/NanoAnalysis/test/prod/samplesNano_2022_Data.csv
@@ -5,33 +5,33 @@ identifier,process,crossSection=-1,BR=1,execute=True,dataset,prefix,pattern,spli
 ###,,,,,,,,,,,/Run2022B-PromptReco-v1 runs 355100-355769 0.0977/fb (prompt nanoAOD not available)
 
 ###,,,,,,,,,,,Run2022C-PromptReco-v1 runs 3355862-357482 5.0707/fb - SingleMuon and DoubleMuon were merged in Run 356426!
-SingleMu2022C,,-1,,,/SingleMuon/Run2022C-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=SingleMuon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py, 
-DoubleMu2022C,,-1,,,/DoubleMuon/Run2022C-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=DoubleMuon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py, 
-Muon2022C  ,,-1,,,/Muon/Run2022C-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
-MuonEG2022C,,-1,,,/MuonEG/Run2022C-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py, # OLD SAMPLE: v1-v1 not yet available?
-EGamma2022C,,  -1,,,/EGamma/Run2022C-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
+SingleMu2022C,,-1,,,/SingleMuon/Run2022C-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=SingleMuon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py, 
+DoubleMu2022C,,-1,,,/DoubleMuon/Run2022C-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=DoubleMuon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py, 
+Muon2022C  ,,-1,,,/Muon/Run2022C-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+MuonEG2022C,,-1,,,/MuonEG/Run2022C-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py, # OLD SAMPLE: v1-v1 not yet available?
+EGamma2022C,,  -1,,,/EGamma/Run2022C-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
 
 ###,,,,,,,,,,,Run2022D-PromptReco-v1 runs 357538-357733
-Muon2022Dv1  ,,-1,,,/Muon/Run2022D-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
-MuonEG2022Dv1,,-1,,,/MuonEG/Run2022D-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
-EGamma2022Dv1,,  -1,,,/EGamma/Run2022D-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
+Muon2022Dv1  ,,-1,,,/Muon/Run2022D-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+MuonEG2022Dv1,,-1,,,/MuonEG/Run2022D-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+EGamma2022Dv1,,  -1,,,/EGamma/Run2022D-PromptNanoAODv10_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
 
 ###,,,,,,,,,,,Run2022D-PromptReco-v2 runs 357734-357900  3.0063/fb (total for 2022D v1+v2)
-Muon2022Dv2  ,,-1,,,/Muon/Run2022D-PromptNanoAODv10_v2-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
-MuonEG2022Dv2,,-1,,,/MuonEG/Run2022D-PromptNanoAODv10_v2-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
-EGamma2022Dv2,,  -1,,,/EGamma/Run2022D-PromptNanoAODv10_v2-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
+Muon2022Dv2  ,,-1,,,/Muon/Run2022D-PromptNanoAODv10_v2-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+MuonEG2022Dv2,,-1,,,/MuonEG/Run2022D-PromptNanoAODv10_v2-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+EGamma2022Dv2,,  -1,,,/EGamma/Run2022D-PromptNanoAODv10_v2-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
 
 ###,,,,,,,,,,,Run20223E-PromptReco-v1 runs 359022-360331 5.878/fb
-Muon2022E  ,,-1,,,/Muon/Run2022E-PromptNanoAODv10_v1-v3/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
-MuonEG2022E,,-1,,,/MuonEG/Run2022E-PromptNanoAODv10_v1-v3/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
-EGamma2022E,,  -1,,,/EGamma/Run2022E-PromptNanoAODv10_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,# OLD SAMPLE: v1-v3 not yet available?
+Muon2022E  ,,-1,,,/Muon/Run2022E-PromptNanoAODv10_v1-v3/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+MuonEG2022E,,-1,,,/MuonEG/Run2022E-PromptNanoAODv10_v1-v3/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+EGamma2022E,,  -1,,,/EGamma/Run2022E-PromptNanoAODv10_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,# OLD SAMPLE: v1-v3 not yet available?
 
 ###,,,,,,,,,,,Run20223F-PromptReco-v1 runs 360390-362167 18.0070/fb
-Muon2022F  ,,-1,,,/Muon/Run2022F-PromptNanoAODv11_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
-MuonEG2022F,,-1,,,/MuonEG/Run2022F-PromptNanoAODv10_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
-EGamma2022F,,  -1,,,/EGamma/Run2022F-PromptNanoAODv11_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
+Muon2022F  ,,-1,,,/Muon/Run2022F-PromptNanoAODv11_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+MuonEG2022F,,-1,,,/MuonEG/Run2022F-PromptNanoAODv11_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+EGamma2022F,,  -1,,,/EGamma/Run2022F-PromptNanoAODv11_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
 
 ###,,,,,,,,,,,Run20223G-PromptReco-v1 runs 362433-362760 3.1219/fb
-Muon2022G  ,,-1,,,/Muon/Run2022G-PromptNanoAODv11_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
-MuonEG2022G,,-1,,,/MuonEG/Run2022G-PromptNanoAODv11_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
-EGamma2022G,,  -1,,,/EGamma/Run2022G-PromptNanoAODv11_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=True,RecoProbabilities.py,
+Muon2022G  ,,-1,,,/Muon/Run2022G-PromptNanoAODv11_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+MuonEG2022G,,-1,,,/MuonEG/Run2022G-PromptNanoAODv11_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+EGamma2022G,,  -1,,,/EGamma/Run2022G-PromptNanoAODv11_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,

--- a/NanoAnalysis/test/prod/samplesNano_2023_Data.csv
+++ b/NanoAnalysis/test/prod/samplesNano_2023_Data.csv
@@ -1,0 +1,8 @@
+identifier,process,crossSection=-1,BR=1,execute=True,dataset,prefix,pattern,splitLevel,::variables,::pyFragments,comment
+
+
+###,,,,,,,,,,,Run2032B runs 366365-
+Muon2023B  ,,-1,,,/Muon0/Run2023B-PromptNanoAODv11p9_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2023;ADDZTREE=False,RecoProbabilities.py,
+MuonEG2023B,,-1,,,/MuonEG/Run2023B-PromptNanoAODv11p9_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2023;ADDZTREE=False,RecoProbabilities.py,
+EGamma2023B,,  -1,,,/EGamma0/Run2023B-PromptNanoAODv11p9_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2023;ADDZTREE=False,RecoProbabilities.py,
+

--- a/NanoAnalysis/test/runLocal.py
+++ b/NanoAnalysis/test/runLocal.py
@@ -13,7 +13,7 @@ SampleToRun = "MCsync_UL"
 ### Customize processing variables
 #setConf("runMELA", False)
 #setConf("bestCandByMELA", False)
-setConf("APPLYMUCORR", False)
+setConf("APPLYMUCORR", False) #NOTE: mu corrections removed for comparision with mini since they are not deterministic on nanoAOD.
 
 ## Select specific events to debug
 #setConf("preselection","run==316239  && luminosityBlock==226 && event==284613817")

--- a/NanoAnalysis/test/syncTrees.py
+++ b/NanoAnalysis/test/syncTrees.py
@@ -19,6 +19,7 @@ verbose = False
 # 2017 UL ggH, 26000 events
 cjlstFile   = "../../AnalysisStep/test/ZZ4lAnalysis_sync_ggH2017_106X_nomuscale.root" 
 nanoFile = "ggH125_2017UL_fixedFSR_nomucorr_full.root"
+#nanoFile = "ggH125_2017UL_fixedFSR_Skim.root"
 
 
 compareWeights = False
@@ -83,7 +84,7 @@ while treeMini.GetEntry(iEntryMini):
         elif region == '3P1F' : iBC = treeNano.ZLLbest3P1FIdx
 
 
-        if iBC < 0 or treeNano.HLT_passZZ4l: # no candidate passes the selection
+        if iBC < 0 or not treeNano.HLT_passZZ4l: # no candidate passes the selection
             # in this event, or the event does not pass the required triggers
             # (for samples processed with TRIGPASSTHROUGH=True)
             foundNano[iEntryNano] = True


### PR DESCRIPTION
* Fixes for CRs:
  * LL for SIP CR now done with full sel (including ID and iso) without SIP
  * Add lepton indices for ZLL candidates
* Prepare for 2023 data (initial csv file, allow for LEPTON_SETUP)
* Add helper to retrieve the leptons belonging to a candidate

