### PR TITLE
Sort Z leptons; replace custom ptython bindings with genreflex ones

### DIFF
--- a/AnalysisStep/interface/kFactors.h
+++ b/AnalysisStep/interface/kFactors.h
@@ -1,0 +1,13 @@
+#ifndef KFACTORS_H
+#define KFACTORS_H
+// We wrap kFactor functions in a struct so that it is possible to generate a
+// dictionary for it
+
+struct KFactors {
+  static float kfactor_qqZZ_qcd_dPhi(float GENabsdPhiZZ, int finalState);  
+  static float xsec_qqZZ_qcd_M(float GenMassZZ, int finalState, int order);
+  static float kfactor_qqZZ_qcd_M(float GENmassZZ, int finalState, int order);
+  static float kfactor_qqZZ_qcd_Pt(float GENpTZZ, int finalState);
+};
+#endif
+

--- a/AnalysisStep/src/LeptonSFHelper.cc
+++ b/AnalysisStep/src/LeptonSFHelper.cc
@@ -159,7 +159,9 @@ float LeptonSFHelper::getSF(int year, int flav, float pt, float eta, float SCeta
             RecoSF = h_Ele_Reco_highPT_2018->GetBinContent(h_Ele_Reco_highPT_2018->GetXaxis()->FindBin(SCeta),h_Ele_Reco_highPT_2018->GetYaxis()->FindBin(std::min(pt,499.f)));
          }
       }
-      else {
+      else if (year >= 2022) {
+	  RecoSF  = 1.; // FIXME2022 not yet implemented
+      } else {
          edm::LogError("LeptonSFHelper::") << "Ele SFs for " << year << " is not supported!";
          abort();
       }
@@ -202,11 +204,11 @@ float LeptonSFHelper::getSF(int year, int flav, float pt, float eta, float SCeta
             }
       }
 
-      else if (year == 2022) {
-	  SelSF  = 1.; // FIXME not yet implemented
+      else if (year >= 2022) {
+	  SelSF  = 1.; // FIXME2022 not yet implemented
       } else {
-      edm::LogError("LeptonSFHelper::") << "Ele SFs for " << year << " is not supported!";
-      abort();
+	edm::LogError("LeptonSFHelper::") << "Ele SFs for " << year << " is not supported!";
+	abort();
       }
 
       SF = RecoSF*SelSF;
@@ -226,7 +228,7 @@ float LeptonSFHelper::getSF(int year, int flav, float pt, float eta, float SCeta
       else if(year == 2018)
       {
          SelSF = h_Mu_SF_2018->GetBinContent(h_Mu_SF_2018->GetXaxis()->FindBin(eta),h_Mu_SF_2018->GetYaxis()->FindBin(std::min(pt,199.f))); //last bin contains the overflow
-      } else if (year ==2022) {
+      } else if (year >=2022) {
 	 SelSF  = 1.; // FIXME not yet implemented
       } else {
          edm::LogError("LeptonSFHelper::") << "Muon SFs for " << year << " is not supported!";
@@ -288,6 +290,10 @@ float LeptonSFHelper::getSFError(int year, int flav, float pt, float eta, float 
             RecoSF_Unc = h_Ele_Reco_highPT_2018->GetBinError(h_Ele_Reco_highPT_2018->GetXaxis()->FindBin(SCeta),h_Ele_Reco_highPT_2018->GetYaxis()->FindBin(std::min(pt,499.f)));
          }
       }
+      else if(year >= 2022) {
+	RecoSF =1.; // FIXME2022 not yet implemented
+	RecoSF_Unc=0.;
+      }
       else {
          edm::LogError("LeptonSFHelper::") << "Ele SFs for " << year << " is not supported!";
          abort();
@@ -336,8 +342,10 @@ float LeptonSFHelper::getSFError(int year, int flav, float pt, float eta, float 
             SelSF_Unc = h_Ele_notCracks_2018->GetBinError(h_Ele_notCracks_2018->FindFixBin(SCeta, std::min(pt,499.f)));
          }
       }
-
-
+      else if(year >= 2022) {
+	SelSF =1.; // FIXME2022 not yet implemented
+	SelSF_Unc=0.;
+      }
       else {
          edm::LogError("LeptonSFHelper::") << "Ele SFs for " << year << " is not supported!";
          abort();
@@ -373,28 +381,5 @@ float LeptonSFHelper::getSFError(int year, int flav, float pt, float eta, float 
    }
 
    return SFError;
-}
-
-// Add C bindings for python
-#include <new>
-extern "C" {
-  void* get_LeptonSFHelper(void) {
-    return new(std::nothrow) LeptonSFHelper(false);
-  }
-
-  void del_LeptonSFHelper(void* ptr) {
-    delete (reinterpret_cast<LeptonSFHelper*>(ptr));
-  }
-
-  float LeptonSFHelper_getSF(void* ptr, int year, int flav, float pt, float eta, float SCeta, bool isCrack) {
-    LeptonSFHelper * ref = reinterpret_cast<LeptonSFHelper*>(ptr);
-    return ref->getSF(year, flav, pt, eta, SCeta, isCrack);
-  }
-
-  float LeptonSFHelper_getSFError(void* ptr, int year, int flav, float pt, float eta, float SCeta, bool isCrack) {
-    LeptonSFHelper * ref = reinterpret_cast<LeptonSFHelper*>(ptr);
-    return ref->getSFError(year, flav, pt, eta, SCeta, isCrack);
-  }
-
 }
 

--- a/AnalysisStep/src/classes.h
+++ b/AnalysisStep/src/classes.h
@@ -1,6 +1,11 @@
 #include <DataFormats/PatCandidates/interface/PFParticle.h>
 #include <DataFormats/PatCandidates/interface/UserData.h>
+#include <ZZAnalysis/AnalysisStep/interface/LeptonSFHelper.h>
+#include <ZZAnalysis/AnalysisStep/interface/kFactors.h>
 #include <vector>
+
 
 edm::Ptr<pat::PFParticle> dummy1;
 pat::UserHolder<std::vector<edm::Ptr<pat::PFParticle> > > dummy2;
+
+#include <JHUGenMELA/MELA/interface/Mela.h>

--- a/AnalysisStep/src/classes_def.xml
+++ b/AnalysisStep/src/classes_def.xml
@@ -1,7 +1,8 @@
 <lcgdict>
-
   <class name="edm::Ptr<pat::PFParticle>"/>
   <class name="std::vector<edm::Ptr<pat::PFParticle> >"/>
   <class name="pat::UserHolder<std::vector<edm::Ptr<pat::PFParticle> > >" />
-
+  <class name="LeptonSFHelper"/>
+  <class name="KFactors"/>
+  <class name="Mela" />
 </lcgdict>

--- a/AnalysisStep/src/kFactors.C
+++ b/AnalysisStep/src/kFactors.C
@@ -1,4 +1,6 @@
- float kfactor_qqZZ_qcd_dPhi(float GENabsdPhiZZ, int finalState)
+#include <ZZAnalysis/AnalysisStep/interface/kFactors.h>
+
+float KFactors::kfactor_qqZZ_qcd_dPhi(float GENabsdPhiZZ, int finalState)
 {
 
     // finalState=1 : 4e/4mu/4tau
@@ -76,7 +78,7 @@
 
 }
 
-float xsec_qqZZ_qcd_M(float GenMassZZ, int finalState, int order){ // Order: 0=LO, 1=NLO, 2=NNLO
+float KFactors::xsec_qqZZ_qcd_M(float GenMassZZ, int finalState, int order){ // Order: 0=LO, 1=NLO, 2=NNLO
   const int nbins=20;
   static const float xsec[2][nbins][4]={
     {
@@ -131,7 +133,7 @@ float xsec_qqZZ_qcd_M(float GenMassZZ, int finalState, int order){ // Order: 0=L
   if (cbin<0) cbin=nbins-1;
   return xsec[finalState-1][cbin][order+1];
 }
-float kfactor_qqZZ_qcd_M(float GENmassZZ, int finalState, int order) // Order: 1=NLO, 2=NNLO
+float KFactors::kfactor_qqZZ_qcd_M(float GENmassZZ, int finalState, int order) // Order: 1=NLO, 2=NNLO
 {
   // finalState=1 : 4e/4mu/4tau
   // finalState=2 : 2e2mu/2mutau/2e2tau
@@ -144,7 +146,7 @@ float kfactor_qqZZ_qcd_M(float GENmassZZ, int finalState, int order) // Order: 1
 }
 
 
-float kfactor_qqZZ_qcd_Pt(float GENpTZZ, int finalState)
+float KFactors::kfactor_qqZZ_qcd_Pt(float GENpTZZ, int finalState)
 {
 
     // finalState=1 : 4e/4mu/4tau

--- a/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
+++ b/AnalysisStep/test/Ntuplizers/HZZ4lNtupleMaker.cc
@@ -66,7 +66,7 @@
 
 
 #include "ZZAnalysis/AnalysisStep/interface/EwkCorrections.h"
-#include "ZZAnalysis/AnalysisStep/src/kFactors.C"
+#include "ZZAnalysis/AnalysisStep/interface/kFactors.h"
 #include <ZZAnalysis/AnalysisStep/interface/bitops.h>
 #include <ZZAnalysis/AnalysisStep/interface/LeptonIsoHelper.h>
 #include <ZZAnalysis/AnalysisStep/interface/PhotonIDHelper.h>
@@ -2060,9 +2060,9 @@ void HZZ4lNtupleMaker::FillKFactors(edm::Handle<GenEventInfoProduct>& genInfo, s
         // Calculate NNLO/NLO QCD K factors for qqZZ
         if (apply_K_NNLOQCD_ZZQQB){
           bool sameflavor=(genZLeps.at(0)->pdgId()*genZLeps.at(1)->pdgId() == genZLeps.at(2)->pdgId()*genZLeps.at(3)->pdgId());
-          KFactor_QCD_qqZZ_dPhi = kfactor_qqZZ_qcd_dPhi(fabs(GenZ1Phi-GenZ2Phi), (sameflavor) ? 1 : 2);
-          KFactor_QCD_qqZZ_M    = kfactor_qqZZ_qcd_M(GenHMass, (sameflavor) ? 1 : 2, 2) / kfactor_qqZZ_qcd_M(GenHMass, (sameflavor) ? 1 : 2, 1);
-          KFactor_QCD_qqZZ_Pt   = kfactor_qqZZ_qcd_Pt(GenHPt, (sameflavor) ? 1 : 2);
+          KFactor_QCD_qqZZ_dPhi = KFactors::kfactor_qqZZ_qcd_dPhi(fabs(GenZ1Phi-GenZ2Phi), (sameflavor) ? 1 : 2);
+          KFactor_QCD_qqZZ_M    = KFactors::kfactor_qqZZ_qcd_M(GenHMass, (sameflavor) ? 1 : 2, 2) / KFactors::kfactor_qqZZ_qcd_M(GenHMass, (sameflavor) ? 1 : 2, 1);
+          KFactor_QCD_qqZZ_Pt   = KFactors::kfactor_qqZZ_qcd_Pt(GenHPt, (sameflavor) ? 1 : 2);
         }
         // Calculate NLO EWK K factors for qqZZ
         if (apply_K_NLOEW_ZZQQB){
@@ -2074,7 +2074,7 @@ void HZZ4lNtupleMaker::FillKFactors(edm::Handle<GenEventInfoProduct>& genInfo, s
           KFactor_EW_qqZZ = EwkCorrections::getEwkCorrections(genParticles, ewkTable, genInfoP, GENZ1Vec, GENZ2Vec);
 
           bool sameflavor=(genZLeps.at(0)->pdgId()*genZLeps.at(1)->pdgId() == genZLeps.at(2)->pdgId()*genZLeps.at(3)->pdgId());
-          float K_NNLO_LO = kfactor_qqZZ_qcd_M(GenHMass, (sameflavor) ? 1 : 2, 2);
+          float K_NNLO_LO = KFactors::kfactor_qqZZ_qcd_M(GenHMass, (sameflavor) ? 1 : 2, 2);
           float rho = GENZZVec.Pt()/(GenLep1Pt+GenLep2Pt+GenLep3Pt+GenLep4Pt);
           if (rho<0.3) KFactor_EW_qqZZ_unc = fabs((K_NNLO_LO-1.)*(1.-KFactor_EW_qqZZ));
           else KFactor_EW_qqZZ_unc = fabs(1.-KFactor_EW_qqZZ);

--- a/NanoAnalysis/python/ZZFiller.py
+++ b/NanoAnalysis/python/ZZFiller.py
@@ -8,10 +8,11 @@ from __future__ import print_function
 from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
 from PhysicsTools.NanoAODTools.postprocessing.tools import *
+from ROOT import LeptonSFHelper
 
 from functools import cmp_to_key
-from ctypes import CDLL, c_float, c_int, c_bool
-from JHUGenMELA.MELA.mela import Mela, SimpleParticle_t, SimpleParticleCollection_t, TVar
+from ROOT import Mela, SimpleParticle_t, SimpleParticleCollection_t, TVar, TLorentzVector
+from ctypes import c_float
 
 class StoreOption:
     # Define which candidates should be stored:
@@ -85,15 +86,11 @@ class ZZFiller(Module):
         # Data-MC SFs. 
         # NanoAODTools provides a module based on LeptonEfficiencyCorrector.cc, but that does not seem to be flexible enough for us:
         # https://github.com/cms-nanoAOD/nanoAOD-tools/blob/master/python/postprocessing/modules/common/lepSFProducer.py
-        self.lib = CDLL('libZZAnalysisAnalysisStep.so') # used for also for MELA c-constants
-        self.lepSFHelper = self.lib.get_LeptonSFHelper() # Note for 2016 UL samples: requires passing bool preVFP
-        self.lib.LeptonSFHelper_getSF.restype = c_float
-        self.lib.LeptonSFHelper_getSFError.restype = c_float
+        self.lepSFHelper = LeptonSFHelper(False) # FIXME for 2016 UL samples: requires passing bool preVFP
 
         if self.runMELA :
             self.mela = Mela(13, 125, TVar.ERROR)
             self.mela.setCandidateDecayMode(TVar.CandidateDecay_ZZ)
-            self.lib.D_bkg_kin.restype = c_float        
 
 
         # Example of adding control histograms (requires self.writeHistFile = True)
@@ -105,7 +102,7 @@ class ZZFiller(Module):
 
 
     def endJob(self):
-        self.lib.del_LeptonSFHelper(self.lepSFHelper)
+        pass
 
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
@@ -215,7 +212,12 @@ class ZZFiller(Module):
                         else:
                             continue
                         
-                        aZ = self.ZCand(i, j, leps, fsrPhotons)
+                        # Set a default order for OS leptons in the Z candidate: 1=l+, 2=l-
+                        idx1, idx2 = i, j
+                        if (l1.pdgId*l2.pdgId<0 and l1.pdgId>0) :
+                            idx1, idx2 = idx2, idx1
+                        
+                        aZ = self.ZCand(idx1, idx2, leps, fsrPhotons)
                         aZ.isOSSF = isOSSF
                         aZ.isSR   = isSR
                         aZ.is1FCR = is1FCR
@@ -473,7 +475,6 @@ class ZZFiller(Module):
     # NOTE: We may need to move Zs into the Event as persistent objects, and to be re-used for CRs. They would be built by a separate module in that case.
     class ZCand: 
         def __init__(self, l1Idx, l2Idx, leps, fsrPhotons):
-            # FIXME: we may want to set a default order for i, j (eg 1=-, 2=+)
             self.l1Idx = l1Idx
             self.l2Idx = l2Idx
             self.l1 = leps[l1Idx]
@@ -532,8 +533,8 @@ class ZZFiller(Module):
            mySCeta = min(mySCeta,2.49)
            mySCeta = max(mySCeta,-2.49)
 
-           SF = self.lib.LeptonSFHelper_getSF(self.lepSFHelper, c_int(self.year), c_int(myLepID), c_float(lep.pt), c_float(lep.eta), c_float(mySCeta), c_bool(isCrack))
-#           SF_Unc = lepSFHelper.getSFError(year,myLepID,lep.pt,lep.eta, mySCeta, isCrack)
+           SF = self.lepSFHelper.getSF(self.year, myLepID, lep.pt, lep.eta, mySCeta, isCrack)
+#           SF_Unc = self.lepSFHelper.getSFError(year, myLepID, lep.pt, lep.eta, mySCeta, isCrack)
            dataMCWeight *= SF
 
        return dataMCWeight
@@ -621,9 +622,12 @@ class ZZFiller(Module):
             daughters.push_back(SimpleParticle_t(Z2.l2.pdgId, Z2.l2DressedP4))
             self.mela.setInputEvent(daughters, 0, 0, 0)
             self.mela.setProcess(TVar.HSMHiggs, TVar.JHUGen, TVar.ZZGG)
-            p_GG_SIG_ghg2_1_ghz1_1_JHUGen = self.mela.computeP(True)
+            res = c_float(0.)
+            self.mela.computeP(res,True)
+            p_GG_SIG_ghg2_1_ghz1_1_JHUGen = res.value
             self.mela.setProcess(TVar.bkgZZ, TVar.MCFM, TVar.ZZQQB)
-            p_QQB_BKG_MCFM = self.mela.computeP(True)
+            self.mela.computeP(res,True)
+            p_QQB_BKG_MCFM = res.value
             self.mela.resetInputEvent()
         if (p_GG_SIG_ghg2_1_ghz1_1_JHUGen+p_QQB_BKG_MCFM == 0.) :
             print ("ERROR", p_GG_SIG_ghg2_1_ghz1_1_JHUGen, p_QQB_BKG_MCFM)

--- a/NanoAnalysis/python/weightFiller.py
+++ b/NanoAnalysis/python/weightFiller.py
@@ -36,18 +36,10 @@ class weightFiller(Module):
             for i in range(0,9) :
                  for i in range(0,9) :
                      self.spkfactor_ggzz_nlo[i] = (ggZZKFactorFile.Get('sp_kfactor_%s' % strZZGGKFVar[i])).Clone('sp_kfactor_%s_NNLO' % strZZGGKFVar[i])
-            ggZZKFactorFile.Close()            
-
-        # qqZZ QCD K-fatcors (for qqZZ)
-        # We include these using plain root, but the code could be called directly from the .so lib
-        if self.APPLY_K_NNLOQCD_ZZQQB :
-            if "/kFactors_C.so" not in ROOT.gSystem.GetLibraries() :
-                p_helper = basePath+'src/kFactors.C+'
-                print('Loading C++ helper from ' + p_helper)
-                ROOT.gROOT.ProcessLine('.L ' + p_helper)
-            self.kfactor_qqZZ_qcd_M = ROOT.kfactor_qqZZ_qcd_M
+            ggZZKFactorFile.Close()
 
         if self.APPLY_K_NNLOEW_ZZQQB :
+            #FIXME: TO BE IMPLEMENTED
             #ewkTable = EwkCorrections::readFile_and_loadEwkTable(basePath+'data/kfactors/ZZ_EwkCorrections.dat')
             pass
 
@@ -116,7 +108,7 @@ class weightFiller(Module):
             flavor = 1 # same Z flavors
             if event.GenZZ_FinalState == 14641 or event.GenZZ_FinalState == 28561 or event.GenZZ_FinalState == 50625 :
                 flavor = 2 # differenr Z flavors
-            KFactor_QCD_qqZZ_M = self.kfactor_qqZZ_qcd_M(event.GenZZ_mass, flavor, 2)/self.kfactor_qqZZ_qcd_M(event.GenZZ_mass, flavor, 1)
+            KFactor_QCD_qqZZ_M = ROOT.KFactors.kfactor_qqZZ_qcd_M(event.GenZZ_mass, flavor, 2)/ROOT.KFactors.kfactor_qqZZ_qcd_M(event.GenZZ_mass, flavor, 1)
 
         if self.APPLY_K_NNLOEW_ZZQQB :
             KFactor_EW_qqZZ = 1 #FIXME: this is 1 up to 2*mZ. To be implemented for higher masses.

--- a/NanoAnalysis/test/prod/samplesNano_2023_Data.csv
+++ b/NanoAnalysis/test/prod/samplesNano_2023_Data.csv
@@ -1,8 +1,11 @@
 identifier,process,crossSection=-1,BR=1,execute=True,dataset,prefix,pattern,splitLevel,::variables,::pyFragments,comment
 
 
-###,,,,,,,,,,,Run2032B runs 366365-
-Muon2023B  ,,-1,,,/Muon0/Run2023B-PromptNanoAODv11p9_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2023;ADDZTREE=False,RecoProbabilities.py,
+###,,,,,,,,,,,Run2032B runs 366365-367079
+Muon02023B  ,,-1,,,/Muon0/Run2023B-PromptNanoAODv11p9_v1-v2/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2023;ADDZTREE=False,RecoProbabilities.py,
+Muon12023B  ,,-1,,,/Muon1/Run2023B-PromptNanoAODv11p9_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2023;ADDZTREE=False,RecoProbabilities.py,
 MuonEG2023B,,-1,,,/MuonEG/Run2023B-PromptNanoAODv11p9_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2023;ADDZTREE=False,RecoProbabilities.py,
-EGamma2023B,,  -1,,,/EGamma0/Run2023B-PromptNanoAODv11p9_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2023;ADDZTREE=False,RecoProbabilities.py,
+EGamma02023B,,  -1,,,/EGamma0/Run2023B-PromptNanoAODv11p9_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2023;ADDZTREE=False,RecoProbabilities.py,
+EGamma12023B,,  -1,,,/EGamma1/Run2023B-PromptNanoAODv11p9_v1-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;ADDLOOSEELE=False;LEPTON_SETUP=2023;ADDZTREE=False,RecoProbabilities.py,
 
+###,,,,,,,,,,,Run2032C runs 367095 - 

--- a/NanoAnalysis/test/syncTrees.py
+++ b/NanoAnalysis/test/syncTrees.py
@@ -11,7 +11,7 @@ region = 'SR'
 #region = '2P2F'
 #region = 'SS'
 
-verbose = False
+verbose = 1
 
 #cjlstFile   = "../../AnalysisStep/test/ZZ4lAnalysis_sync_ggH_102X.root" 
 #nanoFile = "ggH125_Rereco_fixedFSR.root"
@@ -21,11 +21,16 @@ cjlstFile   = "../../AnalysisStep/test/ZZ4lAnalysis_sync_ggH2017_106X_nomuscale.
 nanoFile = "ggH125_2017UL_fixedFSR_nomucorr_full.root"
 #nanoFile = "ggH125_2017UL_fixedFSR_Skim.root"
 
+#2022 MC ggH, 13k events
+#cjlstFile = "../../AnalysisStep/test/ZZ4lAnalysis_sync_SRCR.root"
+#nanoFile = "e5e2fe04-7fb1-43ed-a81a-3acded81f0e7_Skim.root"
+
+
 
 compareWeights = False
-compareKD = False
+compareKD = True
 compareExtra = True and region == 'SR' # FIXME to be implemented for CRs
-massTolerance = 0.03 # in GeV; account for rounding due to data packing
+massTolerance = 0.05 # in GeV; account for rounding due to data packing
 
 if region == 'SR' :
     treeMiniName = 'ZZTree/candTree'
@@ -56,12 +61,42 @@ lastfound = -1
 
 h_m4lDiff = TH1F("h_m4lDiff","h_m4lDiff", 2000, -1, 1)
 
+def printLeps_mini(treeMini, prefix="") :
+    print(prefix, end="")
+    for i in range(4): print(treeMini.LepLepId[i], '{:.3f} {:.3f}'.format(treeMini.LepPt[i], treeMini.LepEta[i]), end=" ")
+    print()
+
+def printLeps_nano(treeNano, prefix) :
+    print(prefix, end="")
+    lepPts = list(treeNano.Electron_pt) + list(treeNano.Muon_pt)
+    lepIds = list(treeNano.Electron_pdgId) + list(treeNano.Muon_pdgId)
+    lepEtas = list(treeNano.Electron_eta) + list(treeNano.Muon_eta)
+    nanoLepIdxs = [eval(nanoPrefix+'Z1l1Idx[iBC]'),eval(nanoPrefix+'Z1l2Idx[iBC]'), eval(nanoPrefix+'Z2l1Idx[iBC]'),eval(nanoPrefix+'Z2l2Idx[iBC]')]
+    case1 = False
+    case2 = False
+    if verbose>0 : 
+        for i, lIdx in enumerate(nanoLepIdxs) :
+            print(lepIds[lIdx], '{:.3f} {:.3f}'.format(lepPts[lIdx], lepEtas[lIdx]), end=" ")        
+            laId = abs(lepIds[lIdx])
+            lPt = lepPts[lIdx]
+            laEta = abs(lepEtas[lIdx])
+
+            if (laId == 11 and laEta>2.49) or laEta > 2.39 :
+                case1 = True
+                print ("*", end="")
+            if laId == 11 and lPt > 9. and lPt < 11.:
+                case2 = True
+                print ("**", end="")
+        print()
+        if case1 : print ("   * : close to eta bound")
+        if case2 : print ("   ** : electron close to 10 GeV pt threshold")
+
 
 while treeMini.GetEntry(iEntryMini):
 
     iEntryMini+=1
 
-    if verbose and iEntryMini%100==0 :
+    if verbose>=2 and iEntryMini%100==0 :
         print ("...", iEntryMini)
     
     if region == 'SR' :
@@ -132,24 +167,22 @@ while treeMini.GetEntry(iEntryMini):
         elif m4lDiff>massTolerance or abs(treeMini.Z1Mass-t2_Z1Mass)>massTolerance or abs(treeMini.Z2Mass-t2_Z2Mass)>massTolerance:
             # check for FSR
             
-            print("Mass Diff: "+str(treeMini.RunNumber)+":"+str(treeMini.LumiNumber)+":"+str(treeMini.EventNumber),
-                  "mini:", '{:.2f} {:.2f} {:.2f} {:.4f} {:.4f} {:.2f}'.format(treeMini.ZZMass,treeMini.Z1Mass,treeMini.Z2Mass, ps1, pb1, KD_mini), "hasFSR:",t1_hasFSR ,
-                  "nano:", '{:.2f} {:.2f} {:.2f} {:.2f}'.format(t2_ZZMass, t2_Z1Mass, t2_Z2Mass, eval(nanoPrefix+'KD[iBC]')), "hasFSR:", t2_hasFSR)
+            print("Mass Diff: "+str(treeMini.RunNumber)+":"+str(treeMini.LumiNumber)+":"+str(treeMini.EventNumber), m4lDiff)
+            print("   mini:", '{:.2f} {:.2f} {:.2f} {:.4f} {:.4f} {:.2f}'.format(treeMini.ZZMass,treeMini.Z1Mass,treeMini.Z2Mass, ps1, pb1, KD_mini), "hasFSR:",t1_hasFSR , "\n"
+                  "   nano:", '{:.2f} {:.2f} {:.2f} {:.2f}'.format(t2_ZZMass, t2_Z1Mass, t2_Z2Mass, eval(nanoPrefix+'KD[iBC]')), "hasFSR:", t2_hasFSR)
             if region=='SR': #FIXME
-                print ("   mini: ", end ="")
-                for i in range(4): print(treeMini.LepLepId[i], treeMini.LepPt[i], end=" ")
-                nanoLepIdxs = [eval(nanoPrefix+'Z1l1Idx[iBC]'),eval(nanoPrefix+'Z1l2Idx[iBC]'), eval(nanoPrefix+'Z2l1Idx[iBC]'),eval(nanoPrefix+'Z2l2Idx[iBC]')]
-                lepPts = list(treeNano.Electron_pt) + list(treeNano.Muon_pt)
-                lepIds = list(treeNano.Electron_pdgId) + list(treeNano.Muon_pdgId)
-                print ("\n   nano: ", end="")
-                for i, lIdx in enumerate(nanoLepIdxs) :
-                    print(lepIds[lIdx], lepPts[lIdx], end=" ")
-                print()
+                printLeps_mini(treeMini, "   mini: ")                
+                printLeps_nano(treeNano, "   nano: ")
 
         if compareExtra :
             if(t2_nExtraLep!=treeMini.nExtraLep or t2_nExtraZ!=treeMini.nExtraZ) :
                 print("nExtra diff:"+str(treeMini.RunNumber)+":"+str(treeMini.LumiNumber)+":"+str(treeMini.EventNumber),
                       treeMini.nExtraLep, t2_nExtraLep, treeMini.nExtraZ, t2_nExtraZ)
+        if compareKD:
+            KD_nano = eval(nanoPrefix+'KD[iBC]')
+            if abs(1.-KD_nano/KD_mini) > 0.005 :
+                print("KD diff: "+str(treeMini.RunNumber)+":"+str(treeMini.LumiNumber)+":"+str(treeMini.EventNumber),KD_mini, KD_nano)
+
 
 #treeMini.Z2Mass
 
@@ -165,11 +198,14 @@ while treeMini.GetEntry(iEntryMini):
         nMatch+=1
     else :
         print("Missing in nano: "+str(treeMini.RunNumber)+":"+str(treeMini.LumiNumber)+":"+str(treeMini.EventNumber), treeMini.ZZsel)
+        print('   {:.2f} {:.2f} {:.2f}'.format(treeMini.ZZMass,treeMini.Z1Mass,treeMini.Z2Mass), "hasFSR:",t1_hasFSR)
+        printLeps_mini(treeMini, "   ")
 
 for iEntryNano,found in enumerate(foundNano):
     if not found:
         treeNano.GetEntry(iEntryNano)
         print("Missing in mini: "+str(treeNano.run)+":"+str(treeNano.luminosityBlock)+":"+str(treeNano.event))
+        printLeps_nano(treeNano, "   ")
 
 print("Matches in", region, ":", nMatch)
 print("max m4l diff:", maxM4lDiff)


### PR DESCRIPTION
- Z Leptons sorted as in miniAOD (+, -)
- use genreflex dictionaries for MELA, kFactors, LeptonSFHelpers instead of ad-hoc bindings