### PR TITLE
[GenFiller]: Add genFiller module for fiducial measurements

### DIFF
--- a/NanoAnalysis/python/branchsel_out_MC.txt
+++ b/NanoAnalysis/python/branchsel_out_MC.txt
@@ -19,5 +19,5 @@ keep Z* # Z and ZZ
 keep GenZZ*
 keep *eight # Generator_weight + custom weights
 keep nDressedLeptons
-keep GenDressedLeps_*
-keep GenZ*
+keep FidDressedLeps_*
+keep FidZ*

--- a/NanoAnalysis/python/branchsel_out_MC.txt
+++ b/NanoAnalysis/python/branchsel_out_MC.txt
@@ -18,4 +18,8 @@ keep best* # bestZ and ZZ indexes
 keep Z* # Z and ZZ
 keep GenZZ*
 keep *eight # Generator_weight + custom weights
-
+keep nDressedLeptons
+keep DressedLeptons_pt
+keep GenRelIso
+keep passedFiducial
+keep GenZ*

--- a/NanoAnalysis/python/branchsel_out_MC.txt
+++ b/NanoAnalysis/python/branchsel_out_MC.txt
@@ -23,3 +23,4 @@ keep DressedLeptons_pt
 keep GenRelIso
 keep passedFiducial
 keep GenZ*
+keep GEN* # Gen-level observables for H cand

--- a/NanoAnalysis/python/branchsel_out_MC.txt
+++ b/NanoAnalysis/python/branchsel_out_MC.txt
@@ -19,8 +19,5 @@ keep Z* # Z and ZZ
 keep GenZZ*
 keep *eight # Generator_weight + custom weights
 keep nDressedLeptons
-keep DressedLeptons_pt
-keep GenRelIso
-keep passedFiducial
+keep GenDressedLeps_*
 keep GenZ*
-keep GEN* # Gen-level observables for H cand

--- a/NanoAnalysis/python/genFiller.py
+++ b/NanoAnalysis/python/genFiller.py
@@ -1,0 +1,230 @@
+### Analyze MC Truth
+# -Optionally dump MC history
+# -Add ZZ gen valriables:
+# -GenZZFinalState: product of IDs of the four gen ZZ leptons
+# -GenZZ_*Idx: ZZ lepton indices in the GenPart collection (FIXME: unsorted)
+# -FsrPhoton_genFsrIdx: index of the closest gen FSR from Z->l (e, mu)
+# 
+###
+
+from __future__ import print_function
+from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
+from PhysicsTools.NanoAODTools.postprocessing.tools import deltaR
+from ROOT import TLorentzVector
+
+ZMASS = 91.1876
+MIN_MZ1 = 40
+MAX_MZ1 = 120
+MIN_MZ2 = 12
+MAX_MZ2 = 120
+
+class genFiller(Module):
+    def __init__(self, dump=False):
+        print("-----> INIT GEN FILLER <-----")
+        self.writeHistFile = False
+
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        self.out = wrappedOutputTree
+        self.out.branch("nDressedLeptons", "I")
+        self.out.branch("DressedLeptons_pt", "F", lenVar="nDressedLeptons")
+        self.out.branch("GenRelIso", "F", lenVar="nDressedLeptons")
+
+    # Find particle's real mother, (first parent in MC history with a different pdgID)
+    def Mother(self, part, gen) :
+        idxMother= part.genPartIdxMother
+        while idxMother>=0 and gen[idxMother].pdgId == part.pdgId:
+            idxMother = gen[idxMother].genPartIdxMother
+        idMother=0
+        if idxMother >=0 : idMother = gen[idxMother].pdgId
+        return idxMother, idMother
+
+    # Return the ID of the leptons's parent: 25 for H->Z->l; 23 for Z->l; +-15 for tau->l if genlep is e,mu.
+    def getParentID(self, part, gen) :
+        pIdx, pID = self.Mother(part, gen)
+        if pIdx < 0 : return 0
+        ppIdx = gen[pIdx].genPartIdxMother
+        if pID == 23 and ppIdx>=0 and gen[ppIdx].pdgId == 25 :
+            pID = 25
+        return pID
+
+    def dressLeptons(self, genpart, packedpart):
+        lep_dressed = TLorentzVector()
+        lep_dressed.SetPtEtaPhiM(genpart.pt, genpart.eta, genpart.phi, genpart.mass)
+        for pp in packedpart :
+            if pp.status != 1: continue
+            if pp.pdgId != 22: continue
+            dR_lgamma = deltaR(genpart.eta, genpart.phi, pp.eta, pp.phi)
+            idMatch = False
+            if pp.genPartIdxMother < 0: continue
+            if (packedpart[pp.genPartIdxMother].pdgId == genpart.pdgId): idMatch = True
+
+            if not idMatch: continue
+
+            if dR_lgamma < 0.3:
+                lep_dressed += pp.p4()
+
+        return lep_dressed
+
+    def computeGenIso(self, current_lepton, packedpart):
+        genIso = 0.0
+        for pp in packedpart :
+            if pp.status != 1: continue
+            if ((abs(pp.pdgId) != 12) or (abs(pp.pdgId) != 14) or (abs(pp.pdgId) != 16)): continue 
+            if ((abs(pp.pdgId) == 11) or (abs(pp.pdgId) == 13)): continue
+            # TODO: include if (gen_fsrset.find(k)!=gen_fsrset.end()) continue;
+            dRvL = deltaR(current_lepton.Eta(), current_lepton.Phi(), pp.eta, pp.phi)
+            if dRvL<0.3:
+                genIso += pp.pt
+        return genIso
+
+    def GenHiggsCounter(self, nGENHiggs):
+        nGENHiggs += 1
+        # TODO : Create H cand from gp
+
+    def buildLLPair(self, l1, l2):
+        l_a = TLorentzVector()
+        l_b = TLorentzVector()
+        l_a.SetPtEtaPhiM(l1.Pt(), l1.Eta(), l1.Phi(), l1.M())
+        l_b.SetPtEtaPhiM(l2.Pt(), l2.Eta(), l2.Phi(), l2.M())
+
+        return l_a, l_b
+
+    def buildZ1Mass(self, Leptons, LeptonsId, makeCuts):
+        offshell = 999.0
+        findZ1 = False
+        idx_l1 = 0
+        idx_l2 = 0
+        for i, l1 in enumerate(Leptons):
+            for j, l2 in enumerate(Leptons):
+                if j <= i : continue
+                if ((LeptonsId[i] + LeptonsId[j]) != 0) : continue
+                l_i, l_j = self.buildLLPair(l1, l2)
+
+                # TODO: Implement pt, eta, Iso cuts
+                ## if (makeCuts and self.checkCuts()) : continue
+
+                mll = TLorentzVector()
+                mll = l_i + l_j
+                if(abs(mll.M() - ZMASS) < offshell) :
+                    mZ1 = mll.M()
+                    idx_l1 = i
+                    idx_l2 = j
+                    findZ1 = True
+                    offshell = abs(mZ1 - ZMASS)
+
+        return offshell, findZ1, idx_l1, idx_l2
+
+    def buildZ2Mass(self, Leptons, LeptonsId, idx_l1, idx_l2, makeCuts):
+        pT_l3l4 = 0.0
+        idx_l3 = 0
+        idx_l4 = 0
+        findZ2 = False
+        for i, l1 in enumerate(Leptons):
+            if ((i == idx_l1) or (i == idx_l2)) : continue
+            for j, l2 in enumerate(Leptons):
+                if j <= i : continue
+                if ((j == idx_l1) or (j == idx_l2)) : continue
+                if ((LeptonsId[i] + LeptonsId[j]) != 0) : continue
+                l_i, l_j = self.buildLLPair(l1, l2)
+
+                Z2 = TLorentzVector()
+                Z2 = l_i + l_j
+
+                # TODO: Implement pt, eta, Iso cuts
+                ## if (makeCuts and self.checkCuts()) : continue
+
+                if (l_i.Pt() + l_j.Pt() >= pT_l3l4):
+                    mass_Z2 = Z2.M()
+                    if ((mass_Z2>MIN_MZ2 and mass_Z2<MAX_MZ2) or (not makeCuts)) :
+                        findZ2 = True
+                        idx_l3 = i
+                        idx_l4 = j
+                        pT_l3l4 = l_i.Pt() + l_j.Pt()
+                    else :
+                        if not findZ2:
+                            idx_l3 = i
+                            idx_l4 = j
+        return findZ2, idx_l3, idx_l4
+
+    def buildZMasses(self, Leptons, LeptonsId, makeCuts = False):
+        passFidSel = False
+        passZ1 = False
+
+        offshell, findZ1, idx_l1, idx_l2 = self.buildZ1Mass(Leptons, LeptonsId, makeCuts)
+
+        z1_l1 = Leptons[idx_l1]
+        z1_l2 = Leptons[idx_l2]
+        l1, l2 = self.buildLLPair(z1_l1, z1_l2)
+        ml1l2 = TLorentzVector()
+        ml1l2 = l1 + l2
+
+        if (ml1l2.M()>MIN_MZ1 and ml1l2.M()<MAX_MZ1 and findZ1) : passZ1 = True
+        if not makeCuts : passZ1 = True
+
+        findZ2, idx_l3, idx_l4 = self.buildZ2Mass(Leptons, LeptonsId, idx_l1, idx_l2, makeCuts)
+
+        z_leps_idx = [idx_l1, idx_l2, idx_l3, idx_l4]
+
+        if (passZ1 and findZ2) : passFidSel = True
+
+        return passFidSel, z_leps_idx
+
+    def buildZCands(self, Leptons, LeptonsId):
+        passFidSel_noCuts, z_leps_idx = self.buildZMasses(Leptons, LeptonsId)
+        if passFidSel_noCuts:
+            l1 = Leptons[z_leps_idx[0]]; l2 = Leptons[z_leps_idx[1]]
+            l3 = Leptons[z_leps_idx[2]]; l4 = Leptons[z_leps_idx[3]]
+            Z1_l1, Z1_l2 = self.buildLLPair(l1, l2)
+            Z2_l1, Z2_l2 = self.buildLLPair(l3, l4)
+        return Z1_l1, Z1_l2, Z2_l1, Z2_l2
+
+    def init_collections(self):
+        Leptons = []
+        LeptonsId = []
+        LeptonsReco = []
+
+        return Leptons, LeptonsId, LeptonsReco
+
+    def analyze(self, event):
+        """process event, return True (go to next module) or False (fail, go to next event)"""
+
+        genpart=Collection(event,"GenPart")
+
+        dressedLeptons = [-1]*len(genpart)
+        Lepts_RelIso   = [-1]*len(genpart)
+
+        nGENHiggs = 0.0
+
+        Leptons, LeptonsId, LeptonsReco = self.init_collections()
+
+        for i, gp in enumerate(genpart) :
+            if ((abs(gp.pdgId) == 11) or (abs(gp.pdgId) == 13) or (abs(gp.pdgId) == 15)) :
+                if (not((gp.status == 1) or (abs(gp.pdgId) == 15))): continue
+                # TODO: Check conditions on motherID
+                # if (!(genAna.MotherID(&genParticles->at(j))==23 || genAna.MotherID(&genParticles->at(j))==443 || genAna.MotherID(&genParticles->at(j))==553 || abs(genAna.MotherID(&genParticles->at(j)))==24) ) continue;
+
+                # Dress leptons
+                # PackedGenParticles in miniAOD is GenPart.status == 1
+                lep_dressed = self.dressLeptons(gp, genpart)
+                Leptons.append(lep_dressed)
+                LeptonsId.append(gp.pdgId)
+                # LeptonsReco # TODO : Figure out (&genParticles->at(j));
+
+                current_lepton = lep_dressed
+                genIso = self.computeGenIso(current_lepton, genpart)
+                genIso = genIso / current_lepton.Pt()
+
+                if (gp.pdgId == 25): self.GenHiggsCounter(nGENHiggs)
+
+                Lepts_RelIso[i] = genIso
+                dressedLeptons[i] = lep_dressed.Pt()
+
+        if(len(Leptons)>=4) :
+            Z1_l1, Z1_l2, Z2_l1, Z2_l2 = self.buildZCands(Leptons, LeptonsId)
+
+        self.out.fillBranch("nDressedLeptons", len(dressedLeptons))
+        self.out.fillBranch("DressedLeptons_pt", dressedLeptons)
+        self.out.fillBranch("GenRelIso", Lepts_RelIso)
+        return True
+

--- a/NanoAnalysis/python/genFiller.py
+++ b/NanoAnalysis/python/genFiller.py
@@ -29,6 +29,10 @@ class genFiller(Module):
         self.out.branch("nDressedLeptons", "I")
         self.out.branch("DressedLeptons_pt", "F", lenVar="nDressedLeptons")
         self.out.branch("GenRelIso", "F", lenVar="nDressedLeptons")
+        self.out.branch("GenZ1Mass", "F")
+        self.out.branch("GenZ2Mass", "F")
+        self.out.branch("GenZZMass", "F")
+        self.out.branch("passedFiducial", "B")
 
     # Find particle's real mother, (first parent in MC history with a different pdgID)
     def Mother(self, part, gen) :
@@ -90,7 +94,35 @@ class genFiller(Module):
 
         return l_a, l_b
 
-    def buildZ1Mass(self, Leptons, LeptonsId, makeCuts):
+    def unzipLeptons(self, LeptonsCollection):
+        Leptons, LeptonsId, Lepts_RelIso = LeptonsCollection
+        return Leptons, LeptonsId, Lepts_RelIso
+
+    def checkCuts(self, LeptonsCollection, idx_1, idx_2):
+        passCuts = True
+        Leptons, LeptonsId, Lepts_RelIso = self.unzipLeptons(LeptonsCollection)
+        id_1 = LeptonsId[idx_1]; id_2 = LeptonsId[idx_2]
+        l_1 = Leptons[idx_1]; l_2 = Leptons[idx_2]
+        iso_1 = Lepts_RelIso[idx_1]; iso_2 = Lepts_RelIso[idx_2]
+
+        if (abs(id_1) == 13 and (l_1.Pt() < 5.0 or abs(l_1.Eta()) > 2.4)) :
+            passCuts = False
+        if (abs(id_1) == 11 and (l_1.Pt() < 7.0 or abs(l_1.Eta()) > 2.5)) :
+            passCuts = False
+        if (iso_1 > 0.35) :
+            passCuts = False
+
+        if (abs(id_2) == 13 and (l_2.Pt() < 5.0 or abs(l_2.Eta()) > 2.4)) :
+            passCuts = False
+        if (abs(id_2) == 11 and (l_2.Pt() < 7.0 or abs(l_2.Eta()) > 2.5)) :
+            passCuts = False
+        if (iso_2 > 0.35) :
+            passCuts = False
+
+        return passCuts
+
+    def buildZ1Mass(self, LeptonsCollection, makeCuts):
+        Leptons, LeptonsId, Lepts_RelIso = self.unzipLeptons(LeptonsCollection)
         offshell = 999.0
         findZ1 = False
         idx_l1 = 0
@@ -101,8 +133,8 @@ class genFiller(Module):
                 if ((LeptonsId[i] + LeptonsId[j]) != 0) : continue
                 l_i, l_j = self.buildLLPair(l1, l2)
 
-                # TODO: Implement pt, eta, Iso cuts
-                ## if (makeCuts and self.checkCuts()) : continue
+                passCuts = self.checkCuts(LeptonsCollection, i, j)
+                if (makeCuts and not passCuts) : continue
 
                 mll = TLorentzVector()
                 mll = l_i + l_j
@@ -115,7 +147,8 @@ class genFiller(Module):
 
         return offshell, findZ1, idx_l1, idx_l2
 
-    def buildZ2Mass(self, Leptons, LeptonsId, idx_l1, idx_l2, makeCuts):
+    def buildZ2Mass(self, LeptonsCollection, idx_l1, idx_l2, makeCuts):
+        Leptons, LeptonsId, Lepts_RelIso = self.unzipLeptons(LeptonsCollection)
         pT_l3l4 = 0.0
         idx_l3 = 0
         idx_l4 = 0
@@ -131,8 +164,8 @@ class genFiller(Module):
                 Z2 = TLorentzVector()
                 Z2 = l_i + l_j
 
-                # TODO: Implement pt, eta, Iso cuts
-                ## if (makeCuts and self.checkCuts()) : continue
+                passCuts = self.checkCuts(LeptonsCollection, i, j)
+                if (makeCuts and not passCuts) : continue
 
                 if (l_i.Pt() + l_j.Pt() >= pT_l3l4):
                     mass_Z2 = Z2.M()
@@ -147,11 +180,12 @@ class genFiller(Module):
                             idx_l4 = j
         return findZ2, idx_l3, idx_l4
 
-    def buildZMasses(self, Leptons, LeptonsId, makeCuts = False):
+    def buildZMasses(self, LeptonsCollection, makeCuts = False):
+        Leptons, LeptonsId, Lepts_RelIso = self.unzipLeptons(LeptonsCollection)
         passFidSel = False
         passZ1 = False
 
-        offshell, findZ1, idx_l1, idx_l2 = self.buildZ1Mass(Leptons, LeptonsId, makeCuts)
+        offshell, findZ1, idx_l1, idx_l2 = self.buildZ1Mass(LeptonsCollection, makeCuts)
 
         z1_l1 = Leptons[idx_l1]
         z1_l2 = Leptons[idx_l2]
@@ -162,7 +196,7 @@ class genFiller(Module):
         if (ml1l2.M()>MIN_MZ1 and ml1l2.M()<MAX_MZ1 and findZ1) : passZ1 = True
         if not makeCuts : passZ1 = True
 
-        findZ2, idx_l3, idx_l4 = self.buildZ2Mass(Leptons, LeptonsId, idx_l1, idx_l2, makeCuts)
+        findZ2, idx_l3, idx_l4 = self.buildZ2Mass(LeptonsCollection, idx_l1, idx_l2, makeCuts)
 
         z_leps_idx = [idx_l1, idx_l2, idx_l3, idx_l4]
 
@@ -170,14 +204,92 @@ class genFiller(Module):
 
         return passFidSel, z_leps_idx
 
-    def buildZCands(self, Leptons, LeptonsId):
-        passFidSel_noCuts, z_leps_idx = self.buildZMasses(Leptons, LeptonsId)
-        if passFidSel_noCuts:
-            l1 = Leptons[z_leps_idx[0]]; l2 = Leptons[z_leps_idx[1]]
-            l3 = Leptons[z_leps_idx[2]]; l4 = Leptons[z_leps_idx[3]]
-            Z1_l1, Z1_l2 = self.buildLLPair(l1, l2)
-            Z2_l1, Z2_l2 = self.buildLLPair(l3, l4)
+    def getZCands(self, Leptons, z_leps_idx):
+        l1 = Leptons[z_leps_idx[0]]; l2 = Leptons[z_leps_idx[1]]
+        l3 = Leptons[z_leps_idx[2]]; l4 = Leptons[z_leps_idx[3]]
+        Z1_l1, Z1_l2 = self.buildLLPair(l1, l2)
+        Z2_l1, Z2_l2 = self.buildLLPair(l3, l4)
+
         return Z1_l1, Z1_l2, Z2_l1, Z2_l2
+
+    def getZIndex(self, LeptonsId, z_leps_idx):
+        idx_1 = LeptonsId[z_leps_idx[0]]; idx_2 = LeptonsId[z_leps_idx[1]]
+        idx_3 = LeptonsId[z_leps_idx[2]]; idx_4 = LeptonsId[z_leps_idx[3]]
+
+        return idx_1, idx_2, idx_3, idx_4
+
+    def getExtraLeps(self, LeptonsCollection, passFidSel, z_leps_idx):
+        Leptons, LeptonsId, Lepts_RelIso = self.unzipLeptons(LeptonsCollection)
+
+        ExtraLeps = [-1]*len(Leptons)
+        ExtraLepsId = [-1]*len(Leptons)
+
+        if passFidSel:
+            for idx, l_i in enumerate(Leptons):
+                if((idx not in z_leps_idx) and (Lepts_RelIso[idx]<0.35)) :
+                    ExtraLeps[idx] = Leptons[idx]
+                    ExtraLepsId[idx] = LeptonsId[idx]
+
+        return ExtraLeps, ExtraLepsId
+
+    def buildZCands(self, LeptonsCollection, passFidSel, z_idx):
+        Leptons, LeptonsId, Lepts_RelIso = self.unzipLeptons(LeptonsCollection)
+        # TODO: Add a return if the event doesnt pass selection
+        if passFidSel:
+            Z1_l1, Z1_l2, Z2_l1, Z2_l2 = self.getZCands(Leptons, z_idx)
+            idx_1, idx_2, idx_3, idx_4 = self.getZIndex(LeptonsId, z_idx)
+            ZCands = [Z1_l1, Z1_l2, Z2_l1, Z2_l2]
+            ZIdx   = [idx_1, idx_2, idx_3, idx_4]
+            return ZCands, ZIdx
+        else:
+            return [-1]*len(Leptons), [-1]*len(Leptons)
+
+    def countFiducialLeps(self, LeptonsCollection):
+        Leptons, LeptonsId, Lepts_RelIso = self.unzipLeptons(LeptonsCollection)
+
+        nFidLeps = 0; nFidPtLead = 0; nFidPtSubLead = 0
+        for l_i, idx_i, iso_i in zip(Leptons, LeptonsId, Lepts_RelIso):
+            thisLep = TLorentzVector()
+            thisLep.SetPtEtaPhiM(l_i.Pt(), l_i.Eta(), l_i.Phi(), l_i.M())
+            if(((abs(idx_i) == 13 and thisLep.Pt() > 5.0 and abs(thisLep.Eta()) < 2.4)
+                or (abs(idx_i) == 11 and thisLep.Pt() > 7.0 and abs(thisLep.Eta()) < 2.5))
+                and iso_i < 0.35) :
+                nFidLeps += 1
+                if thisLep.Pt() > 20 : nFidPtLead += 1
+                if thisLep.Pt() > 10 : nFidPtSubLead += 1 
+
+        return nFidLeps, nFidPtLead, nFidPtSubLead
+
+    def checkEventTopology(self, LeptonsCollection, zFid_leps_idx):
+        Leptons, LeptonsId, Lepts_RelIso = self.unzipLeptons(LeptonsCollection)
+        passedMassOS = True; passedElMuDeltaR = True; passedDeltaR = True;
+
+        for i, l1 in enumerate(Leptons):
+            for j, l2 in enumerate(Leptons):
+                if j <= i : continue
+                if i not in zFid_leps_idx: continue
+                if j not in zFid_leps_idx: continue
+                l_i, l_j = self.buildLLPair(l1, l2)
+                mll = TLorentzVector()
+                mll = l_i + l_j
+
+                if(LeptonsId[i]*LeptonsId[j]<0):
+                    if(mll.M()<=4):
+                        passedMassOS = False
+                        break
+
+                deltaR_ll = deltaR(l_i.Eta(), l_i.Phi(), l_j.Eta(), l_j.Phi())
+
+                if(abs(LeptonsId[i]) != abs(LeptonsId[j])):
+                    if(deltaR_ll<=0.02):
+                        passedElMuDeltaR = False
+                        break
+
+                if deltaR_ll <= 0.02:
+                    passedDeltaR = False
+                    break
+
+        return passedMassOS, passedElMuDeltaR, passedDeltaR
 
     def init_collections(self):
         Leptons = []
@@ -209,7 +321,6 @@ class genFiller(Module):
                 lep_dressed = self.dressLeptons(gp, genpart)
                 Leptons.append(lep_dressed)
                 LeptonsId.append(gp.pdgId)
-                # LeptonsReco # TODO : Figure out (&genParticles->at(j));
 
                 current_lepton = lep_dressed
                 genIso = self.computeGenIso(current_lepton, genpart)
@@ -220,11 +331,41 @@ class genFiller(Module):
                 Lepts_RelIso[i] = genIso
                 dressedLeptons[i] = lep_dressed.Pt()
 
-        if(len(Leptons)>=4) :
-            Z1_l1, Z1_l2, Z2_l1, Z2_l2 = self.buildZCands(Leptons, LeptonsId)
+        LeptonsCollection = [Leptons, LeptonsId, Lepts_RelIso]
+
+        if(len(Leptons)>=4):
+            passFidSel_noCut, z_leps_idx = self.buildZMasses(LeptonsCollection)
+            ZCands_noCut, ZIdx_noCut = self.buildZCands(LeptonsCollection, passFidSel_noCut, z_leps_idx)
+
+        nFidLeps, nFidPtLead, nFidPtSubLead = self.countFiducialLeps(LeptonsCollection)
+        passFidSel = False
+
+        if(nFidLeps >= 4 and nFidPtLead >= 1 and nFidPtSubLead >= 2) :
+            passFidSel, zFid_leps_idx = self.buildZMasses(LeptonsCollection, makeCuts = True)
+            ZCands_fidSel, ZIdx_fidSel = self.buildZCands(LeptonsCollection, passFidSel, zFid_leps_idx)
+            ExtraLep_fidSel, ExtraLepIdx_fidSel = self.getExtraLeps(LeptonsCollection, passFidSel, zFid_leps_idx)
+
+            passedMassOS, passedElMuDeltaR, passedDeltaR = self.checkEventTopology(LeptonsCollection, zFid_leps_idx)
+            if((passedMassOS == False) or (passedElMuDeltaR == False) or (passedDeltaR == False)): passFidSel = False
+            if ZCands_fidSel[0] == -1:
+                z1mass = -1
+                z2mass = -1
+                zzmass = -1
+            else:
+                z1mass = (ZCands_fidSel[0]+ZCands_fidSel[1]).M()
+                z2mass = (ZCands_fidSel[2]+ZCands_fidSel[3]).M()
+                zzmass = (ZCands_fidSel[0]+ZCands_fidSel[1]+ZCands_fidSel[2]+ZCands_fidSel[3]).M()
+
+            self.out.fillBranch("GenZ1Mass", z1mass)
+            self.out.fillBranch("GenZ2Mass", z2mass)
+            self.out.fillBranch("GenZZMass", zzmass)
+
+            # TODO: Add GenJets
 
         self.out.fillBranch("nDressedLeptons", len(dressedLeptons))
         self.out.fillBranch("DressedLeptons_pt", dressedLeptons)
         self.out.fillBranch("GenRelIso", Lepts_RelIso)
+        self.out.fillBranch("passedFiducial", passFidSel)
         return True
+
 

--- a/NanoAnalysis/python/genFiller.py
+++ b/NanoAnalysis/python/genFiller.py
@@ -11,6 +11,8 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collect
 from PhysicsTools.NanoAODTools.postprocessing.tools import deltaR
 from ROOT import TLorentzVector
 
+from ZZAnalysis.NanoAnalysis.tools import Mother
+
 ZMASS = 91.1876
 MIN_MZ1 = 40
 MAX_MZ1 = 120
@@ -28,49 +30,20 @@ class genFiller(Module):
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
         self.out.branch("nDressedLeptons", "I")
-        self.out.branch("GenDressedLeps_pt", "F", lenVar="nDressedLeptons")
-        self.out.branch("GenDressedLeps_RelIso", "F", lenVar="nDressedLeptons")
-        self.out.branch("GenZZ_Z1l1Idx", "I") # Indices in the GenPart
-        self.out.branch("GenZZ_Z1l2Idx", "I")
-        self.out.branch("GenZZ_Z2l1Idx", "I")
-        self.out.branch("GenZZ_Z2l2Idx", "I")
-        self.out.branch("GenZZ_mass", "F")
-        self.out.branch("GenZZ_pt", "F")
-        self.out.branch("GenZZ_eta", "F")
-        self.out.branch("GenZZ_phi", "F")
-        self.out.branch("GenZZ_rapidity", "F")
-        self.out.branch("GenZ1_mass", "F")
-        self.out.branch("GenZ2_mass", "F")
+        self.out.branch("FidDressedLeps_pt", "F", lenVar="nDressedLeptons")
+        self.out.branch("FidDressedLeps_RelIso", "F", lenVar="nDressedLeptons")
+        self.out.branch("FidZZ_Z1l1Idx", "I") # Indices in the GenPart
+        self.out.branch("FidZZ_Z1l2Idx", "I")
+        self.out.branch("FidZZ_Z2l1Idx", "I")
+        self.out.branch("FidZZ_Z2l2Idx", "I")
+        self.out.branch("FidZZ_mass", "F")
+        self.out.branch("FidZZ_pt", "F")
+        self.out.branch("FidZZ_eta", "F")
+        self.out.branch("FidZZ_phi", "F")
+        self.out.branch("FidZZ_rapidity", "F")
+        self.out.branch("FidZ1_mass", "F")
+        self.out.branch("FidZ2_mass", "F")
         self.out.branch("passedFiducial", "B")
-
-    def Mother(self, part, gen):
-        '''
-            Find the ID and Idx of the mother of a given GenPart (`part`)
-            amongst all the particles in GenPart (`gen`) collection.
-            The function returns Idx and ID of the mother.
-        '''
-        idxMother= part.genPartIdxMother
-        while idxMother>=0 and gen[idxMother].pdgId == part.pdgId:
-            idxMother = gen[idxMother].genPartIdxMother
-        idMother=0
-        if idxMother >=0 : idMother = gen[idxMother].pdgId
-        return idxMother, idMother
-
-    def lhe_logger(self, genpart):
-        print ("---Gen:")
-        for i, gp in enumerate(genpart) :
-            motherId=-1
-            gmotherId=-1
-            if gp.genPartIdxMother >= 0 : 
-                motherId = genpart[gp.genPartIdxMother].pdgId
-                if genpart[gp.genPartIdxMother].genPartIdxMother >= 0 :
-                    gmotherId = genpart[genpart[gp.genPartIdxMother].genPartIdxMother].pdgId
-            print (i, gp.pdgId, gp.genPartIdxMother, gp.pt, gp.eta, gp.phi, gp.p4().M(), gp.status)
-    
-        print("---------LHEPart---------")
-        LHEPart = Collection (event, "LHEPart")
-        for i, Lp in enumerate(LHEPart):
-            print(i, Lp.pdgId, Lp.pt, Lp.eta, Lp.status, Lp.incomingpz)
 
     def dressLeptons(self, genpart, packedpart):
         '''
@@ -430,17 +403,17 @@ class genFiller(Module):
             z1mass = (ZCands_fidSel[0]+ZCands_fidSel[1]).M()
             z2mass = (ZCands_fidSel[2]+ZCands_fidSel[3]).M()
 
-        self.out.fillBranch("GenZZ_mass", zzmass)
-        self.out.fillBranch("GenZZ_Z1l1Idx", z1l1idx) #FIXME: to be sorted with standard criteria
-        self.out.fillBranch("GenZZ_Z1l2Idx", z1l2idx)
-        self.out.fillBranch("GenZZ_Z2l1Idx", z2l1idx)
-        self.out.fillBranch("GenZZ_Z2l2Idx", z2l2idx)
-        self.out.fillBranch("GenZZ_pt", zzpt)
-        self.out.fillBranch("GenZZ_eta", zzeta)
-        self.out.fillBranch("GenZZ_phi", zzphi)
-        self.out.fillBranch("GenZZ_rapidity", zzrapidity)
-        self.out.fillBranch("GenZ1_mass", z1mass)
-        self.out.fillBranch("GenZ2_mass", z2mass)
+        self.out.fillBranch("FidZZ_mass", zzmass)
+        self.out.fillBranch("FidZZ_Z1l1Idx", z1l1idx) #FIXME: to be sorted with standard criteria
+        self.out.fillBranch("FidZZ_Z1l2Idx", z1l2idx)
+        self.out.fillBranch("FidZZ_Z2l1Idx", z2l1idx)
+        self.out.fillBranch("FidZZ_Z2l2Idx", z2l2idx)
+        self.out.fillBranch("FidZZ_pt", zzpt)
+        self.out.fillBranch("FidZZ_eta", zzeta)
+        self.out.fillBranch("FidZZ_phi", zzphi)
+        self.out.fillBranch("FidZZ_rapidity", zzrapidity)
+        self.out.fillBranch("FidZ1_mass", z1mass)
+        self.out.fillBranch("FidZ2_mass", z2mass)
 
     def analyze(self, event):
         '''
@@ -450,8 +423,6 @@ class genFiller(Module):
         '''
 
         genpart=Collection(event,"GenPart")
-
-        if self.printGenHist : self.lhe_logger()
 
         dressedLeptons = [-1]*len(genpart)
         Lepts_RelIso   = [-1]*len(genpart)
@@ -463,7 +434,7 @@ class genFiller(Module):
         for i, gp in enumerate(genpart) :
             if ((abs(gp.pdgId) == 11) or (abs(gp.pdgId) == 13) or (abs(gp.pdgId) == 15)) :
                 if (not((gp.status == 1) or (abs(gp.pdgId) == 15))): continue
-                mom_idx, mom_id = self.Mother(gp, genpart)
+                mom_idx, mom_id = Mother(gp, genpart)
                 if (not((mom_id==23) or (mom_id==443) or (mom_id==553) or (abs(mom_id)==24))): continue
 
                 # Dress leptons
@@ -504,8 +475,8 @@ class genFiller(Module):
             # TODO: Add MELA
 
         self.out.fillBranch("nDressedLeptons", len(dressedLeptons))
-        self.out.fillBranch("GenDressedLeps_pt", dressedLeptons)
-        self.out.fillBranch("GenDressedLeps_RelIso", Lepts_RelIso)
+        self.out.fillBranch("FidDressedLeps_pt", dressedLeptons)
+        self.out.fillBranch("FidDressedLeps_RelIso", Lepts_RelIso)
         self.out.fillBranch("passedFiducial", passFidSel)
 
         return True

--- a/NanoAnalysis/python/genFiller.py
+++ b/NanoAnalysis/python/genFiller.py
@@ -61,12 +61,12 @@ class genFiller(Module):
         for i, gp in enumerate(genpart) :
             motherId=-1
             gmotherId=-1
-            if gp.genPartIdxMother >= 0 :
+            if gp.genPartIdxMother >= 0 : 
                 motherId = genpart[gp.genPartIdxMother].pdgId
                 if genpart[gp.genPartIdxMother].genPartIdxMother >= 0 :
                     gmotherId = genpart[genpart[gp.genPartIdxMother].genPartIdxMother].pdgId
             print (i, gp.pdgId, gp.genPartIdxMother, gp.pt, gp.eta, gp.phi, gp.p4().M(), gp.status)
-
+    
         print("---------LHEPart---------")
         LHEPart = Collection (event, "LHEPart")
         for i, Lp in enumerate(LHEPart):
@@ -281,29 +281,17 @@ class genFiller(Module):
 
         return Z1_l1, Z1_l2, Z2_l1, Z2_l2
 
-    def getZIndex(self, z_leps_idx):
-        '''
-            Util function that returns the index of the leptons that
-            compose the Z1 and Z2 candidates.
-        '''
-        idx_1 = z_leps_idx[0]; idx_2 = z_leps_idx[1]
-        idx_3 = z_leps_idx[2]; idx_4 = z_leps_idx[3]
-
-        return idx_1, idx_2, idx_3, idx_4
-
-    def getZFlav(self, LeptonsId, z_leps_idx):
+    def getZIndex(self, LeptonsId, z_leps_idx):
         '''
             Util function that returns the IDs of the leptons that
             compose the Z1 and Z2 candidates.
         '''
-        # TODO: Store info in ntuples
-        id_1 = LeptonsId[z_leps_idx[0]]; id_2 = LeptonsId[z_leps_idx[1]]
-        id_3 = LeptonsId[z_leps_idx[2]]; id_4 = LeptonsId[z_leps_idx[3]]
+        # idx_1 = LeptonsId[z_leps_idx[0]]; idx_2 = LeptonsId[z_leps_idx[1]]
+        # idx_3 = LeptonsId[z_leps_idx[2]]; idx_4 = LeptonsId[z_leps_idx[3]]
+        idx_1 = z_leps_idx[0]; idx_2 = z_leps_idx[1]
+        idx_3 = z_leps_idx[2]; idx_4 = z_leps_idx[3]
 
-        z1_flav = id_1*id_2
-        z2_flav = id_3*id_4
-
-        return id_1, id_2, id_3, id_4
+        return idx_1, idx_2, idx_3, idx_4
 
     def getExtraLeps(self, LeptonsCollection, passFidSel, z_leps_idx):
         '''
@@ -335,7 +323,7 @@ class genFiller(Module):
 
         if passFidSel:
             Z1_l1, Z1_l2, Z2_l1, Z2_l2 = self.getZCands(Leptons, z_idx)
-            idx_1, idx_2, idx_3, idx_4 = self.getZIndex(z_idx)
+            idx_1, idx_2, idx_3, idx_4 = self.getZIndex(LeptonsId, z_idx)
             ZCands = [Z1_l1, Z1_l2, Z2_l1, Z2_l2]
             ZIdx   = [idx_1, idx_2, idx_3, idx_4]
             return ZCands, ZIdx
@@ -411,7 +399,7 @@ class genFiller(Module):
 
         return Leptons, LeptonsId, LeptonsReco
 
-    def fill_HCand_branches(self, ZCands_fidSel):
+    def fill_HCand_branches(self, ZCands_fidSel, ZIdx_fidSel):
         '''
             Function that fills branches for gen-level
             Higgs boson candindate.
@@ -420,7 +408,10 @@ class genFiller(Module):
             z1mass = -1
             z2mass = -1
             zzmass = -1
-            zzmass = -1
+            z1l1idx = -1
+            z1l2idx = -1
+            z2l1idx = -1
+            z2l2idx = -1
             zzrapidity = -1
             zzpt = -1
             zzeta = -1
@@ -428,6 +419,10 @@ class genFiller(Module):
         else:
             gen_H_cand = ZCands_fidSel[0]+ZCands_fidSel[1]+ZCands_fidSel[2]+ZCands_fidSel[3]
             zzmass = (gen_H_cand).M()
+            z1l1idx = ZIdx_fidSel[0]
+            z1l2idx = ZIdx_fidSel[1]
+            z2l1idx = ZIdx_fidSel[2]
+            z2l2idx = ZIdx_fidSel[3]
             zzrapidity = (gen_H_cand).Rapidity()
             zzpt = (gen_H_cand).Pt()
             zzeta = (gen_H_cand).Eta()
@@ -436,10 +431,10 @@ class genFiller(Module):
             z2mass = (ZCands_fidSel[2]+ZCands_fidSel[3]).M()
 
         self.out.fillBranch("GenZZ_mass", zzmass)
-        self.out.fillBranch("GenZZ_Z1l1Idx", ZCands_fidSel[0])
-        self.out.fillBranch("GenZZ_Z1l2Idx", ZCands_fidSel[1])
-        self.out.fillBranch("GenZZ_Z2l1Idx", ZCands_fidSel[2])
-        self.out.fillBranch("GenZZ_Z2l2Idx", ZCands_fidSel[3])
+        self.out.fillBranch("GenZZ_Z1l1Idx", z1l1idx) #FIXME: to be sorted with standard criteria
+        self.out.fillBranch("GenZZ_Z1l2Idx", z1l2idx)
+        self.out.fillBranch("GenZZ_Z2l1Idx", z2l1idx)
+        self.out.fillBranch("GenZZ_Z2l2Idx", z2l2idx)
         self.out.fillBranch("GenZZ_pt", zzpt)
         self.out.fillBranch("GenZZ_eta", zzeta)
         self.out.fillBranch("GenZZ_phi", zzphi)
@@ -503,7 +498,7 @@ class genFiller(Module):
             passedMassOS, passedElMuDeltaR, passedDeltaR = self.checkEventTopology(LeptonsCollection, zFid_leps_idx)
             if((passedMassOS == False) or (passedElMuDeltaR == False) or (passedDeltaR == False)): passFidSel = False
 
-            self.fill_HCand_branches(ZCands_fidSel)
+            self.fill_HCand_branches(ZCands_fidSel, ZIdx_fidSel)
 
             # TODO: Add GenJets
             # TODO: Add MELA
@@ -514,3 +509,4 @@ class genFiller(Module):
         self.out.fillBranch("passedFiducial", passFidSel)
 
         return True
+

--- a/NanoAnalysis/python/mcTruthAnalyzer.py
+++ b/NanoAnalysis/python/mcTruthAnalyzer.py
@@ -13,6 +13,7 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collect
 from PhysicsTools.NanoAODTools.postprocessing.tools import deltaR
 from ROOT import TLorentzVector
 
+from ZZAnalysis.NanoAnalysis.tools import Mother, getParentID
 
 class mcTruthAnalyzer(Module):
     def __init__(self, dump=False):
@@ -30,24 +31,6 @@ class mcTruthAnalyzer(Module):
         self.out.branch("GenZZ_Z2l2Idx", "I")
         self.out.branch("FsrPhoton_genFsrIdx", "I", lenVar="nFsrPhoton")
 
-    # Find particle's real mother, (first parent in MC history with a different pdgID)
-    def Mother(self, part, gen) :
-        idxMother= part.genPartIdxMother
-        while idxMother>=0 and gen[idxMother].pdgId == part.pdgId:
-            idxMother = gen[idxMother].genPartIdxMother
-        idMother=0
-        if idxMother >=0 : idMother = gen[idxMother].pdgId
-        return idxMother, idMother
-
-    # Return the ID of the leptons's parent: 25 for H->Z->l; 23 for Z->l; +-15 for tau->l if genlep is e,mu.
-    def getParentID(self, part, gen) :
-        pIdx, pID = self.Mother(part, gen)
-        if pIdx < 0 : return 0
-        ppIdx = gen[pIdx].genPartIdxMother
-        if pID == 23 and ppIdx>=0 and gen[ppIdx].pdgId == 25 :
-            pID = 25
-        return pID
-
     def analyze(self, event):
         """process event, return True (go to next module) or False (fail, go to next event)"""
 
@@ -55,22 +38,8 @@ class mcTruthAnalyzer(Module):
 
         ### Print Gen history and LHE particles.
         ### See also: https://github.com/cms-nanoAOD/nanoAOD-tools/blob/master/python/postprocessing/modules/common/hepmcDump.py
-        if self.printGenHist : 
-            print ("---Gen:")
-            for i, gp in enumerate(genpart) :
-                motherId=-1
-                gmotherId=-1
-                if gp.genPartIdxMother >= 0 : 
-                    motherId = genpart[gp.genPartIdxMother].pdgId
-                    if genpart[gp.genPartIdxMother].genPartIdxMother >= 0 :
-                        gmotherId = genpart[genpart[gp.genPartIdxMother].genPartIdxMother].pdgId
-                print (i, gp.pdgId, gp.genPartIdxMother, gp.pt, gp.eta, gp.phi, gp.p4().M(), gp.status)
-        
-            print("---------LHEPart---------")
-            LHEPart = Collection (event, "LHEPart")
-            for i, Lp in enumerate(LHEPart):
-                print(i, Lp.pdgId, Lp.pt, Lp.eta, Lp.status, Lp.incomingpz)
-
+        if self.printGenHist :
+            lhe_logger(genpart)
 
         ## Search for gen FSR from Z->ll (e, mu)
         genFSRIdxs = []
@@ -79,7 +48,7 @@ class mcTruthAnalyzer(Module):
             if gp.pdgId==22 and gp.pt > 2. and midx >= 0 :
                 mid = genpart[midx].pdgId
                 if abs(mid) == 11 or abs(mid) == 13 :
-                    mmidx, mmid = self.Mother(genpart[midx], genpart) # possibly skip intermediate rows
+                    mmidx, mmid = Mother(genpart[midx], genpart) # possibly skip intermediate rows
                     if mmid == 23 :
                         genFSRIdxs.append(i)
 
@@ -115,7 +84,7 @@ class mcTruthAnalyzer(Module):
             if (p.pdgId)==25 : theGenH = p
             if (abs(p.pdgId)==11 or abs(p.pdgId)==13 or abs(p.pdgId)==15) and p.genPartIdxMother >=0 :
                 mid = genpart[p.genPartIdxMother].pdgId
-                pid = self.getParentID(p, genpart)
+                pid = getParentID(p, genpart)
                 if mid == 25 or (mid == 23 and pid == 25) : # Lepton from H->(Z->)ll; note that this is the first daughter in the H or Z line; ie pre-FSR
                     theGenZZLeps.append(ip)
                 elif ((mid == 23 and pid == 23) or mid == 24): # Associated production, or ZZ (sorted out below).

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -10,6 +10,7 @@ from PhysicsTools.NanoAODTools.postprocessing.tools import *
 
 from ZZAnalysis.NanoAnalysis.tools import setConf, getConf
 from ZZAnalysis.NanoAnalysis.triggerAndSkim import * # Trigger requirements are defined here
+from ZZAnalysis.NanoAnalysis.genFiller import *
 from ZZAnalysis.NanoAnalysis.lepFiller import *
 from ZZAnalysis.NanoAnalysis.jetFiller import *
 from ZZAnalysis.NanoAnalysis.ZZFiller import *
@@ -133,6 +134,7 @@ ZZSequence.extend([lepFiller(cuts, LEPTON_SETUP), # FSR and FSR-corrected iso; f
 if IsMC :
     from ZZAnalysis.NanoAnalysis.mcTruthAnalyzer import *
     ZZSequence.insert(0, mcTruthAnalyzer(dump=False)) # Gen final state
+    ZZSequence.append(genFiller())
 
     from ZZAnalysis.NanoAnalysis.modules.puWeightProducer import *
     if LEPTON_SETUP < 2022 :

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -134,7 +134,7 @@ ZZSequence.extend([lepFiller(cuts, LEPTON_SETUP), # FSR and FSR-corrected iso; f
 if IsMC :
     from ZZAnalysis.NanoAnalysis.mcTruthAnalyzer import *
     ZZSequence.insert(0, mcTruthAnalyzer(dump=False)) # Gen final state
-    ZZSequence.append(genFiller())
+    ZZSequence.append(genFiller(dump=False))
 
     from ZZAnalysis.NanoAnalysis.modules.puWeightProducer import *
     if LEPTON_SETUP < 2022 :

--- a/NanoAnalysis/python/tools.py
+++ b/NanoAnalysis/python/tools.py
@@ -36,3 +36,45 @@ def getLeptons(aCand, event) :
     muons = Collection(event, "Muon")
     leps = list(electrons) + list(muons)
     return [leps[i] for i in idxs]
+
+def Mother(part, gen):
+    '''
+        Find the ID and Idx of the mother of a given GenPart (`part`)
+        amongst all the particles in GenPart (`gen`) collection.
+        The function returns Idx and ID of the mother.
+    '''
+    idxMother= part.genPartIdxMother
+    while idxMother>=0 and gen[idxMother].pdgId == part.pdgId:
+        idxMother = gen[idxMother].genPartIdxMother
+    idMother=0
+    if idxMother >=0 : idMother = gen[idxMother].pdgId
+    return idxMother, idMother
+
+def getParentID(part, gen) :
+    '''
+        Return the ID of the leptons's parent:
+        25 for H->Z->l; 23 for Z->l; +-15 for
+        tau->l if genlep is e,mu.
+    '''
+    pIdx, pID = Mother(part, gen)
+    if pIdx < 0 : return 0
+    ppIdx = gen[pIdx].genPartIdxMother
+    if pID == 23 and ppIdx>=0 and gen[ppIdx].pdgId == 25 :
+        pID = 25
+    return pID
+
+def lhe_logger(genpart):
+    print ("---Gen:")
+    for i, gp in enumerate(genpart) :
+        motherId=-1
+        gmotherId=-1
+        if gp.genPartIdxMother >= 0 : 
+            motherId = genpart[gp.genPartIdxMother].pdgId
+            if genpart[gp.genPartIdxMother].genPartIdxMother >= 0 :
+                gmotherId = genpart[genpart[gp.genPartIdxMother].genPartIdxMother].pdgId
+        print (i, gp.pdgId, gp.genPartIdxMother, gp.pt, gp.eta, gp.phi, gp.p4().M(), gp.status)
+
+    print("---------LHEPart---------")
+    LHEPart = Collection (event, "LHEPart")
+    for i, Lp in enumerate(LHEPart):
+        print(i, Lp.pdgId, Lp.pt, Lp.eta, Lp.status, Lp.incomingpz)


### PR DESCRIPTION
This PR implements the `genFiller.py` module, inspired from the [`GenFiller.cc`](https://github.com/CJLST/ZZAnalysis/blob/Run2UL_22/AnalysisStep/plugins/GenFiller.cc) plugin used in miniAOD. This module aims at defining the fiducial phase space at gen-level and stores in the final `.root` ntuple the relevant branches for fiducial and differential analyses.

The code at the current stage includes:
* All the selection of objects and definition of the fiducial phase space;
* Store to ntuples the information of the ZZ and Z candidates, together with a `bool` flag for events that pass fiducial selections;

Further developments can target:
* Inclusion of MELA discriminants at gen-level (can be postponed, not relevant for early Run3 analysis nor for any other legacy analysis that is not fiducial xsec measurements);
* Inclusion of gen-level jets (can be postponed, not relevant for early Run3 analysis, especially if we don't have reco-level jets);
* Storage to ntuples of leptons IDs, four-vector etc. This is a trivial development, which does not impact the merging of this PR.

Some plots demonstrating the testing of the code:

![image](https://github.com/CJLST/ZZAnalysis/assets/19261234/2ce9531d-2a4b-4be4-b2f4-324bc2105555)
![image](https://github.com/CJLST/ZZAnalysis/assets/19261234/afc409d4-b1cf-4293-b1c1-8e25f16e2ac0)
