### PR TITLE
Update condor scripts for SLC7 to AlmaLinux9 migration

### DIFF
--- a/AnalysisStep/scripts/batch_Condor.py
+++ b/AnalysisStep/scripts/batch_Condor.py
@@ -1,5 +1,6 @@
 #!/bin/env python3
 from __future__ import print_function
+from past.builtins import execfile
 
 import sys
 import imp


### PR DESCRIPTION
This update introduces the following behaviour:
- jobs sent from a SLC7 machines (lxplus7) are forced to land on SLC7 batch nodes;
- jobs sent from AlmaLinux9 machines (lxplus9) are forced to land on AlmaLinux9 batch nodes;
- jobs sent from AlmaLinux8 machines (lxplus9) are forced to land on AlmaLinux9 batch nodes, in a EL8 Singularity container (not recommended, untested)

Further options like sending jobs from SLC7 machines to AlmaLinux9 nodes in a EL7  Singularity container may also be added in the future.
