### PR TITLE
[tools.py] generalize function to get sum of weights

### DIFF
--- a/NanoAnalysis/python/tools.py
+++ b/NanoAnalysis/python/tools.py
@@ -78,3 +78,20 @@ def lhe_logger(genpart):
     LHEPart = Collection (event, "LHEPart")
     for i, Lp in enumerate(LHEPart):
         print(i, Lp.pdgId, Lp.pt, Lp.eta, Lp.status, Lp.incomingpz)
+
+def get_genEventSumw(filename):
+    f = ROOT.TFile.Open(filename)
+
+    runs = f.Runs
+    nRuns = runs.GetEntries()
+    iRun = 0
+    genEventCount = 0
+    genEventSumw = 0.
+
+    while iRun < nRuns and runs.GetEntry(iRun) :
+        genEventCount += runs.genEventCount
+        genEventSumw += runs.genEventSumw
+        iRun +=1
+    print ("gen=", genEventCount, "sumw=", genEventSumw)
+
+    return genEventSumw

--- a/NanoAnalysis/python/tools.py
+++ b/NanoAnalysis/python/tools.py
@@ -79,11 +79,19 @@ def lhe_logger(genpart):
     for i, Lp in enumerate(LHEPart):
         print(i, Lp.pdgId, Lp.pt, Lp.eta, Lp.status, Lp.incomingpz)
 
-def get_genEventSumw(filename):
-    f = ROOT.TFile.Open(filename)
+def get_genEventSumw(input_file, maxEntriesPerSample=None):
+    '''
+       Util function to get the sum of weights per event.
+       Returns the sum of weights, similarly to what we
+       stored in Counters->GetBinContent(40) in the miniAODs.
+    '''
+    f = input_file
 
-    runs = f.Runs
+    runs  = f.Runs
+    event = f.Events
     nRuns = runs.GetEntries()
+    nEntries = event.GetEntries()
+
     iRun = 0
     genEventCount = 0
     genEventSumw = 0.
@@ -93,5 +101,12 @@ def get_genEventSumw(filename):
         genEventSumw += runs.genEventSumw
         iRun +=1
     print ("gen=", genEventCount, "sumw=", genEventSumw)
+
+    if maxEntriesPerSample is not None:
+        print(f"Scaling to {maxEntriesPerSample} entries")
+        if nEntries>maxEntriesPerSample :
+            genEventSumw = genEventSumw*maxEntriesPerSample/nEntries
+            nEntries=maxEntriesPerSample
+        print("    scaled to:", nEntries, "sumw=", genEventSumw)
 
     return genEventSumw

--- a/NanoAnalysis/test/NanoPlotter/H4l_fill.py
+++ b/NanoAnalysis/test/NanoPlotter/H4l_fill.py
@@ -7,7 +7,7 @@ import math
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
-from ZZAnalysis.NanoAnalysis.tools import getLeptons
+from ZZAnalysis.NanoAnalysis.tools import getLeptons, get_genEventSumw
 
 
 pathMC = "/eos/user/n/namapane/H4lnano/220420/" # FIXME: Use 2018 MC for the time being
@@ -58,21 +58,7 @@ def fillHistos(samplename, filename) :
         event.SetBranchStatus("overallEventWeight",1)
 
         # Get sum of weights
-        runs = f.Runs
-        nRuns = runs.GetEntries()
-        iRun = 0
-        genEventCount = 0
-        genEventSumw = 0.
-        while iRun < nRuns and runs.GetEntry(iRun) :
-            genEventCount += runs.genEventCount
-            genEventSumw += runs.genEventSumw
-            iRun +=1
-        print (samplename, ": gen=", genEventCount, "sel=",nEntries, "sumw=", genEventSumw)
-        if nEntries>maxEntriesPerSample :
-            genEventSumw = genEventSumw*maxEntriesPerSample/nEntries
-            nEntries=maxEntriesPerSample
-            print("   scaling to:", nEntries, "sumw=", genEventSumw )
-
+        genEventSumw = get_genEventSumw(f, maxEntriesPerSample)
 
     iEntry=0
     printEntries=max(5000,nEntries/10)


### PR DESCRIPTION
Add `get_genEventSumw` to `tools.py` to get sum of weights from a `.root` file. Returns a single number, equivalent to `Counters->GetBinContent(40)` in miniAOD ntuples.