### PR TITLE
Fix preselection for Z+L. Fix checkout recipe

### DIFF
--- a/AnalysisStep/scripts/batch_Condor.py
+++ b/AnalysisStep/scripts/batch_Condor.py
@@ -392,7 +392,7 @@ class MyBatchManager:
                if inputType == 'miniAOD' :
                    self.jobflavour = 'tomorrow'
                else :
-                   self.jobflavour = 'longlunch'
+                   self.jobflavour = 'workday'
            
        dname = dirname
        if dname  is None:

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -88,11 +88,19 @@ cuts = dict(
     eleFullId = (lambda l, era : cuts["eleRelaxedId"](l) and cuts["passEleBDT"](l, era)),
     )
 
-### Preselection to speed up processing. Note: to be relaxed for CRs
-if ADD_ALLEVENTS :
+### Preselection to speed up processing.
+if ADD_ALLEVENTS : # move preselection after cloneBranches 
     preselection = None
+    if PROCESS_ZL :
+        postPresel = lambda evt : (evt.nMuon+evt.nElectron>=3)
+    else :
+        postPresel = lambda evt : (evt.nMuon+evt.nElectron>=4)        
 else:
-    preselection = "nMuon+nElectron >= 4 && Sum$(Muon_pt > {muPt}-2.)+Sum$(Electron_pt>{elePt})>= 4".format(**cuts)
+    postPresel = None
+    if PROCESS_ZL :
+        preselection = "nMuon+nElectron >= 3 && Sum$(Muon_pt > {muPt}-2.)+Sum$(Electron_pt>{elePt})>= 3".format(**cuts)
+    else :
+        preselection = "nMuon+nElectron >= 4 && Sum$(Muon_pt > {muPt}-2.)+Sum$(Electron_pt>{elePt})>= 4".format(**cuts)
 
 ### Input file specification
 store = getConf("store","") # "/eos/cms/" for files available on eos; "root://cms-xrd-global.cern.ch/" for remote files
@@ -161,7 +169,7 @@ if IsMC:
                                                'overallEventWeight',
                                                ],
                                       #Stop further processing for events that don't have 4 reco leps
-                                      continueFor = lambda evt : (evt.nMuon+evt.nElectron>=4) 
+                                      continueFor = postPresel
                                       ),
                         ] + pre_sequence
 

--- a/NanoAnalysis/test/prod/samplesNano_2022_Data.csv
+++ b/NanoAnalysis/test/prod/samplesNano_2022_Data.csv
@@ -5,28 +5,28 @@ identifier,process,crossSection=-1,BR=1,execute=True,dataset,prefix,pattern,spli
 ###,,,,,,,,,,,/Run2022B-PromptReco-v1 runs 355100-355769 0.0977/fb (prompt nanoAOD not available)
 
 ###,,,,,,,,,,,Run2022C-22Sep2023-v1 - nanoAODv12 - runs 355862 - 357482
-SingleMu2022C,,-1,,,/SingleMuon/Run2022C-22Sep2023-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,5,DATA_TAG=PromptReco;PD=SingleMuon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py, 
-DoubleMu2022C,,-1,,,/DoubleMuon/Run2022C-22Sep2023-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,5,DATA_TAG=PromptReco;PD=DoubleMuon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py, 
-Muon2022C    ,,-1,,,/Muon/Run2022C-22Sep2023-v1/NANOAOD      ,dbs,root://cms-xrd-global.cern.ch/,5,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
-MuonEG2022C  ,,-1,,,/MuonEG/Run2022C-22Sep2023-v1/NANOAOD    ,dbs,root://cms-xrd-global.cern.ch/,5,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
-EGamma2022C  ,,-1,,,/EGamma/Run2022C-22Sep2023-v1/NANOAOD    ,dbs,root://cms-xrd-global.cern.ch/,5,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+SingleMu2022C,,-1,,,/SingleMuon/Run2022C-22Sep2023-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=SingleMuon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py, 
+DoubleMu2022C,,-1,,,/DoubleMuon/Run2022C-22Sep2023-v1/NANOAOD,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=DoubleMuon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py, 
+Muon2022C    ,,-1,,,/Muon/Run2022C-22Sep2023-v1/NANOAOD      ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+MuonEG2022C  ,,-1,,,/MuonEG/Run2022C-22Sep2023-v1/NANOAOD    ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+EGamma2022C  ,,-1,,,/EGamma/Run2022C-22Sep2023-v1/NANOAOD    ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
 
 ###,,,,,,,,,,,Run2022D-22Sep2023-v1 - nanoAODv12 - runs 357538 - 357900
-Muon2022D  ,,-1,,,/Muon/Run2022D-22Sep2023-v1/NANOAOD   ,dbs,root://cms-xrd-global.cern.ch/,5,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
-MuonEG2022D,,-1,,,/MuonEG/Run2022D-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,4,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
-EGamma2022D,,-1,,,/EGamma/Run2022D-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,5,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+Muon2022D  ,,-1,,,/Muon/Run2022D-22Sep2023-v1/NANOAOD   ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+MuonEG2022D,,-1,,,/MuonEG/Run2022D-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+EGamma2022D,,-1,,,/EGamma/Run2022D-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
 
 ###,,,,,,,,,,,Run2022E-22Sep2023-v1 - nanoAODv12 - runs 359356 - 360327
-Muon2022E  ,,-1,,,/Muon/Run2022E-22Sep2023-v1/NANOAOD   ,dbs,root://cms-xrd-global.cern.ch/,4,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
-MuonEG2022E,,-1,,,/MuonEG/Run2022E-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,4,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
-EGamma2022E,,-1,,,/EGamma/Run2022E-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,5,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+Muon2022E  ,,-1,,,/Muon/Run2022E-22Sep2023-v1/NANOAOD   ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+MuonEG2022E,,-1,,,/MuonEG/Run2022E-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+EGamma2022E,,-1,,,/EGamma/Run2022E-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
 
 ###,,,,,,,,,,,Run2022F-22Sep2023-v1 - nanoAODv12 - runs 360335 - 362167
-Muon2022F  ,,-1,,,/Muon/Run2022F-22Sep2023-v2/NANOAOD   ,dbs,root://cms-xrd-global.cern.ch/,4,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
-MuonEG2022F,,-1,,,/MuonEG/Run2022F-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,5,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
-EGamma2022F,,-1,,,/EGamma/Run2022F-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,5,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+Muon2022F  ,,-1,,,/Muon/Run2022F-22Sep2023-v2/NANOAOD   ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+MuonEG2022F,,-1,,,/MuonEG/Run2022F-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+EGamma2022F,,-1,,,/EGamma/Run2022F-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
 
 ###,,,,,,,,,,,Run2022G-22Sep2023-v1 - nanoAODv12 - runs 362353 - 362760
-Muon2022G  ,,-1,,,/Muon/Run2022G-22Sep2023-v1/NANOAOD   ,dbs,root://cms-xrd-global.cern.ch/,5,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
-MuonEG2022G,,-1,,,/MuonEG/Run2022G-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,5,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
-EGamma2022G,,-1,,,/EGamma/Run2022G-22Sep2023-v2/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,5,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+Muon2022G  ,,-1,,,/Muon/Run2022G-22Sep2023-v1/NANOAOD   ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=Muon;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+MuonEG2022G,,-1,,,/MuonEG/Run2022G-22Sep2023-v1/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=MuEG;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,
+EGamma2022G,,-1,,,/EGamma/Run2022G-22Sep2023-v2/NANOAOD ,dbs,root://cms-xrd-global.cern.ch/,2,DATA_TAG=PromptReco;PD=EGamma;PROCESS_CR=True;PROCESS_ZL=True;ADDLOOSEELE=False;LEPTON_SETUP=2022;ADDZTREE=False,RecoProbabilities.py,

--- a/checkout_13X.csh
+++ b/checkout_13X.csh
@@ -64,11 +64,12 @@ sed -i '/SimTracker\/Records/d' KinZfitter/HelperFunction/BuildFile.xml
 sed -i '/SimTracker\/Records/d' KinZfitter/KinZfitter/BuildFile.xml
 
 
-#Pick the fix from #43536, until it is merged
-git cms-addpkg PhysicsTools/NanoAODTools
+#Pick the fix from #43536 (haddNano.py), until it is merged
+git cms-addpkg PhysicsTools/NanoAOD
 git cms-cherry-pick-pr 43536 CMSSW_13_0_X
 
-#Pick more fixes in NanoAODTools
+#Pick more fixes in NanoAODTools (support for "S" branch types)
+git cms-addpkg PhysicsTools/NanoAODTools
 git fetch https://github.com/namapane/cmssw.git NAT-dev:namapane_NAT-dev
 git cherry-pick 3e73ca4c2f8
 


### PR DESCRIPTION
-When the Z+L CR is included, the preselection requires 3 instead of 4 leptons
-Fix checkout recipe - must checkout PhysicsTools/NanoAOD as well to pick the fixed haddnano.py