### PR TITLE
Towards ZX with Nano (part 2)

### DIFF
--- a/AnalysisStep/test/analyzer_Sync_2022.py
+++ b/AnalysisStep/test/analyzer_Sync_2022.py
@@ -6,6 +6,7 @@ LEPTON_SETUP = 2022
 APPLYMUCORR = False  # Switch off muon scale corrections
 APPLYJEC = False     # Switch off JEC
 APPLYJER = False     # Switch off JER
+APPLYNANOSEL = False # Apply same muon selection as in the NanoAOD collection
 RECORRECTMET = False # Switch off MET corr
 #KINREFIT = True    # control KinZFitter (very slow)
 PROCESS_CR = True   # False = Skip CR paths and trees

--- a/NanoAnalysis/python/ZZFiller.py
+++ b/NanoAnalysis/python/ZZFiller.py
@@ -324,10 +324,10 @@ class ZZFiller(Module):
         ### Z+L CR, for fake rate. This is considered only for events with a Z + exactly 1 additional lepton passing the relaxed selection.
         ### This ensures that there is no overlap with the SR and OS, 3P1F and 2P2F CRs (there can be an overlap with the SIP CR
         ### as that keeps leptons failing SIP)
-        if self.addZLCR and bestZIdx >= 0 :
+        if self.addZLCR and bestZIdx >= 0 and SRZs[bestZIdx].M > 40 and SRZs[bestZIdx].M < 120:
             aZ = SRZs[bestZIdx]
             for i,aL in enumerate(leps):
-                # Search for additional lepton, with ghost suppression DR cut 
+                # Search for additional lepton, with ghost suppression DR cut
                 if i != aZ.l1Idx and i!= aZ.l2Idx and aL.ZZRelaxedId and \
                    deltaR(aL.eta, aL.phi, aZ.l1.eta, aZ.l1.phi) > 0.02 and \
                    deltaR(aL.eta, aL.phi, aZ.l2.eta, aZ.l2.phi) > 0.02 :

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -31,7 +31,7 @@ XSEC = getConf("XSEC", 1.)
 SYNCMODE = getConf("SYNCMODE", False)
 runMELA = getConf("runMELA", True)
 bestCandByMELA = getConf("bestCandByMELA", True) # requires also runMELA=True
-TRIGPASSTHROUGH = getConf("TRIGPASSTHROUGH", True) # Do not filter events that do not pass triggers (HLT_passZZ4l records if they did)
+TRIGPASSTHROUGH = getConf("TRIGPASSTHROUGH", False) # Do not filter events that do not pass triggers (HLT_passZZ4l records if they did)
 PROCESS_CR = getConf("PROCESS_CR", False) # fill control regions
 PROCESS_ZL = getConf("PROCESS_ZL", False) # fill ZL control region
 APPLYMUCORR = getConf("APPLYMUCORR", True) # apply muon momentum scale/resolution corrections


### PR DESCRIPTION
Content of the PR:

- Improvement of the script to convert the output of NanoAODs in a MiniAOD-like output (only for CR)
- Added the possibility (APPLYNANOSEL) to process MiniAOD with the same preselection on muons as in NanoAOD
- Included the cut on the mZ1 in the Z+L CR
- Default setting of TRIGPASSTHROUGH to False