### PR TITLE
[ZZFiller.py] Add pt,eta,rapidity,phi obs for ZZ candidates

### DIFF
--- a/NanoAnalysis/python/ZZFiller.py
+++ b/NanoAnalysis/python/ZZFiller.py
@@ -118,9 +118,9 @@ class ZZFiller(Module):
 
         self.out.branch("nZCand", "I", title="Z candidates passing the full H4l selection")
         self.out.branch("ZCand_mass", "F", lenVar="nZCand", title="mass")
-#         self.out.branch("ZCand_pt", "F", lenVar="nZCand")
-#         self.out.branch("ZCand_eta", "F", lenVar="nZCand")
-#         self.out.branch("ZCand_phi", "F", lenVar="nZCand")
+        self.out.branch("ZCand_pt", "F", lenVar="nZCand")
+        self.out.branch("ZCand_eta", "F", lenVar="nZCand")
+        self.out.branch("ZCand_phi", "F", lenVar="nZCand")
         self.out.branch("ZCand_flav", "F", lenVar="nZCand", title="Product of the pdgIds of the 2 daughters")
         self.out.branch("ZCand_l1Idx", "S", lenVar="nZCand", title="index of 1st daughter in Electron+Muon merged collection")
         self.out.branch("ZCand_l2Idx", "S", lenVar="nZCand", title="index of 2nd daughter in Electron+Muon merged collection")
@@ -130,9 +130,10 @@ class ZZFiller(Module):
 
         self.out.branch("nZZCand", "I", title="ZZ candidates passing the full H4l selection")
         self.out.branch("ZZCand_mass", "F", lenVar="nZZCand", title="mass")
-#         self.out.branch("ZZCand_pt", "F", lenVar="nZZCand")
-#         self.out.branch("ZZCand_eta", "F", lenVar="nZZCand")
-#         self.out.branch("ZZCand_phi", "F", lenVar="nZZCand")
+        self.out.branch("ZZCand_pt", "F", lenVar="nZZCand")
+        self.out.branch("ZZCand_eta", "F", lenVar="nZZCand")
+        self.out.branch("ZZCand_rapidity", "F", lenVar="nZZCand")
+        self.out.branch("ZZCand_phi", "F", lenVar="nZZCand")
         self.out.branch("ZZCand_massPreFSR", "F", lenVar="nZZCand", title="mass without FSR photons")
         self.out.branch("ZZCand_Z1mass", "F", lenVar="nZZCand", title="Z1 mass")
         self.out.branch("ZZCand_Z1flav", "I", lenVar="nZZCand", title="Product of the pdgIds of the 2 Z1 daughters")
@@ -159,9 +160,9 @@ class ZZFiller(Module):
             self.out.branch("nZLLCand", "I", title="Z+LL control region candidates")
             self.out.branch("ZLLCand_mass", "F", lenVar="nZLLCand")
             self.out.branch("ZLLCand_massPreFSR", "F", lenVar="nZLLCand")
-#             self.out.branch("ZLLCand_pt", "F", lenVar="nZLLCand")
-#             self.out.branch("ZLLCand_eta", "F", lenVar="nZLLCand")
-#             self.out.branch("ZLLCand_phi", "F", lenVar="nZLLCand")
+            self.out.branch("ZLLCand_pt", "F", lenVar="nZLLCand")
+            self.out.branch("ZLLCand_eta", "F", lenVar="nZLLCand")
+            self.out.branch("ZLLCand_phi", "F", lenVar="nZLLCand")
             self.out.branch("ZLLCand_Z1mass", "F", lenVar="nZLLCand")
             self.out.branch("ZLLCand_Z1flav", "I", lenVar="nZLLCand")
             self.out.branch("ZLLCand_Z2mass", "F", lenVar="nZLLCand")
@@ -352,6 +353,9 @@ class ZZFiller(Module):
         ### Now fill the variables to be stored as output
         # Fill selected Zs
         ZCand_mass = []
+        ZCand_pt = []
+        ZCand_eta = []
+        ZCand_phi = []
         ZCand_flav = []
         ZCand_l1Idx = []
         ZCand_l2Idx = []
@@ -360,9 +364,9 @@ class ZZFiller(Module):
 
         for iZ, aZ in enumerate(SRZs) :
             ZCand_mass.append(aZ.p4.M())
-#            ZCand_pt.append(aZ.p4.pt())
-#            ZCand_eta.append(aZ.p4.eta())
-#            ZCand_phi.append(aZ.p4.phi())
+            ZCand_pt.append(aZ.p4.Pt())
+            ZCand_eta.append(aZ.p4.Eta())
+            ZCand_phi.append(aZ.p4.Phi())
             ZCand_flav.append(aZ.finalState())
             ZCand_l1Idx.append(aZ.l1Idx)
             ZCand_l2Idx.append(aZ.l2Idx)
@@ -370,9 +374,9 @@ class ZZFiller(Module):
             ZCand_fsr2Idx.append(aZ.fsr2Idx)
 
         self.out.fillBranch("ZCand_mass", ZCand_mass)
-#         self.out.fillBranch("ZCand_pt", ZCand_pt)
-#         self.out.fillBranch("ZCand_eta", ZCand_eta)
-#         self.out.fillBranch("ZCand_phi", ZCand_phi)
+        self.out.fillBranch("ZCand_pt", ZCand_pt)
+        self.out.fillBranch("ZCand_eta", ZCand_eta)
+        self.out.fillBranch("ZCand_phi", ZCand_phi)
         self.out.fillBranch("ZCand_flav", ZCand_flav)
         self.out.fillBranch("ZCand_l1Idx", ZCand_l1Idx)
         self.out.fillBranch("ZCand_l2Idx", ZCand_l2Idx)
@@ -383,6 +387,10 @@ class ZZFiller(Module):
         ### Fill ZZ candidates
         ZZCand_mass = [0.]*len(ZZs)
         ZZCand_massPreFSR = [0.]*len(ZZs)
+        ZZCand_pt = [0.]*len(ZZs)
+        ZZCand_eta = [0.]*len(ZZs)
+        ZZCand_rapidity = [0.]*len(ZZs)
+        ZZCand_phi = [0.]*len(ZZs)
         ZZCand_Z1mass = [0.]*len(ZZs)
         ZZCand_Z1flav = [0.]*len(ZZs)
         ZZCand_Z2mass = [0.]*len(ZZs)
@@ -400,6 +408,10 @@ class ZZFiller(Module):
         for iZZ, ZZ in enumerate(ZZs) :
             ZZCand_mass[iZZ] = ZZ.p4.M()
             ZZCand_massPreFSR[iZZ] = ZZ.massPreFSR()
+            ZZCand_pt[iZZ] = ZZ.p4.Pt()
+            ZZCand_eta[iZZ] = ZZ.p4.Eta()
+            ZZCand_rapidity[iZZ] = ZZ.p4.Rapidity()
+            ZZCand_phi[iZZ] = ZZ.p4.Phi()
             ZZCand_Z1mass[iZZ] = ZZ.Z1.M
             ZZCand_Z1flav[iZZ] = ZZ.Z1.finalState()
             ZZCand_Z2mass[iZZ] = ZZ.Z2.M
@@ -421,6 +433,10 @@ class ZZFiller(Module):
 
         self.out.fillBranch("ZZCand_mass", ZZCand_mass)
         self.out.fillBranch("ZZCand_massPreFSR", ZZCand_massPreFSR)
+        self.out.fillBranch("ZZCand_pt", ZZCand_pt)
+        self.out.fillBranch("ZZCand_eta", ZZCand_eta)
+        self.out.fillBranch("ZZCand_rapidity", ZZCand_rapidity)
+        self.out.fillBranch("ZZCand_phi", ZZCand_phi)
         self.out.fillBranch("ZZCand_Z1mass", ZZCand_Z1mass)
         self.out.fillBranch("ZZCand_Z1flav", ZZCand_Z1flav)
         self.out.fillBranch("ZZCand_Z2mass", ZZCand_Z2mass)
@@ -445,9 +461,9 @@ class ZZFiller(Module):
         if self.addSSCR or self. addOSCR or self.addSIPCR :
             ZLLCand_mass   = [0.]*len(ZLLs)
             ZLLCand_massPreFSR = [0.]*len(ZLLs)
-#             ZLLCand_pt     = [0.]*len(ZLLs)
-#             ZLLCand_eta    = [0.]*len(ZLLs)
-#             ZLLCand_phi    = [0.]*len(ZLLs)
+            ZLLCand_pt     = [0.]*len(ZLLs)
+            ZLLCand_eta    = [0.]*len(ZLLs)
+            ZLLCand_phi    = [0.]*len(ZLLs)
             ZLLCand_Z1mass = [0.]*len(ZLLs)
             ZLLCand_Z1flav = [0.]*len(ZLLs)
             ZLLCand_Z2mass = [0.]*len(ZLLs)
@@ -461,9 +477,9 @@ class ZZFiller(Module):
             for iZLL, ZLL in enumerate(ZLLs) :
                 ZLLCand_mass[iZLL] = ZLL.p4.M()
                 ZLLCand_massPreFSR[iZLL] = ZLL.massPreFSR()
-#                 ZLLCand_pt[iZLL] = ZLL.p4.pt()
-#                 ZLLCand_eta[iZLL] = ZLL.p4.eta()
-#                 ZLLCand_phi[iZLL] = ZLL.p4.phi()
+                ZLLCand_pt[iZLL] = ZLL.p4.Pt()
+                ZLLCand_eta[iZLL] = ZLL.p4.Eta()
+                ZLLCand_phi[iZLL] = ZLL.p4.Phi()
                 ZLLCand_Z1mass[iZLL] = ZLL.Z1.M
                 ZLLCand_Z1flav[iZLL] = ZLL.Z1.finalState()
                 ZLLCand_Z2mass[iZLL] = ZLL.Z2.M
@@ -476,9 +492,9 @@ class ZZFiller(Module):
 
             self.out.fillBranch("ZLLCand_mass",   ZLLCand_mass)
             self.out.fillBranch("ZLLCand_massPreFSR",   ZLLCand_massPreFSR)
-#             self.out.fillBranch("ZLLCand_pt",     ZLLCand_pt)
-#             self.out.fillBranch("ZLLCand_eta",    ZLLCand_eta)
-#             self.out.fillBranch("ZLLCand_phi",    ZLLCand_phi)
+            self.out.fillBranch("ZLLCand_pt",     ZLLCand_pt)
+            self.out.fillBranch("ZLLCand_eta",    ZLLCand_eta)
+            self.out.fillBranch("ZLLCand_phi",    ZLLCand_phi)
             self.out.fillBranch("ZLLCand_Z1mass", ZLLCand_Z1mass)
             self.out.fillBranch("ZLLCand_Z1flav", ZLLCand_Z1flav)
             self.out.fillBranch("ZLLCand_Z2mass", ZLLCand_Z2mass)

--- a/NanoAnalysis/python/ZZFiller.py
+++ b/NanoAnalysis/python/ZZFiller.py
@@ -120,6 +120,7 @@ class ZZFiller(Module):
         self.out.branch("ZCand_mass", "F", lenVar="nZCand", title="mass")
         self.out.branch("ZCand_pt", "F", lenVar="nZCand")
         self.out.branch("ZCand_eta", "F", lenVar="nZCand")
+        self.out.branch("ZCand_rapidity", "F", lenVar="nZCand")
         self.out.branch("ZCand_phi", "F", lenVar="nZCand")
         self.out.branch("ZCand_flav", "F", lenVar="nZCand", title="Product of the pdgIds of the 2 daughters")
         self.out.branch("ZCand_l1Idx", "S", lenVar="nZCand", title="index of 1st daughter in Electron+Muon merged collection")
@@ -162,6 +163,7 @@ class ZZFiller(Module):
             self.out.branch("ZLLCand_massPreFSR", "F", lenVar="nZLLCand")
             self.out.branch("ZLLCand_pt", "F", lenVar="nZLLCand")
             self.out.branch("ZLLCand_eta", "F", lenVar="nZLLCand")
+            self.out.branch("ZLLCand_rapidity", "F", lenVar="nZLLCand")
             self.out.branch("ZLLCand_phi", "F", lenVar="nZLLCand")
             self.out.branch("ZLLCand_Z1mass", "F", lenVar="nZLLCand")
             self.out.branch("ZLLCand_Z1flav", "I", lenVar="nZLLCand")
@@ -352,30 +354,33 @@ class ZZFiller(Module):
 
         ### Now fill the variables to be stored as output
         # Fill selected Zs
-        ZCand_mass = []
-        ZCand_pt = []
-        ZCand_eta = []
-        ZCand_phi = []
-        ZCand_flav = []
-        ZCand_l1Idx = []
-        ZCand_l2Idx = []
-        ZCand_fsr1Idx = []
-        ZCand_fsr2Idx = []
+        ZCand_mass = [0.]*len(SRZs)
+        ZCand_pt = [0.]*len(SRZs)
+        ZCand_eta = [0.]*len(SRZs)
+        ZCand_rapidity = [0.]*len(SRZs)
+        ZCand_phi = [0.]*len(SRZs)
+        ZCand_flav = [0.]*len(SRZs)
+        ZCand_l1Idx = [0.]*len(SRZs)
+        ZCand_l2Idx = [0.]*len(SRZs)
+        ZCand_fsr1Idx = [0.]*len(SRZs)
+        ZCand_fsr2Idx = [0.]*len(SRZs)
 
         for iZ, aZ in enumerate(SRZs) :
-            ZCand_mass.append(aZ.p4.M())
-            ZCand_pt.append(aZ.p4.Pt())
-            ZCand_eta.append(aZ.p4.Eta())
-            ZCand_phi.append(aZ.p4.Phi())
-            ZCand_flav.append(aZ.finalState())
-            ZCand_l1Idx.append(aZ.l1Idx)
-            ZCand_l2Idx.append(aZ.l2Idx)
-            ZCand_fsr1Idx.append(aZ.fsr1Idx)
-            ZCand_fsr2Idx.append(aZ.fsr2Idx)
+            ZCand_mass[iZ] = aZ.p4.M()
+            ZCand_pt[iZ] = aZ.p4.Pt()
+            ZCand_eta[iZ] = aZ.p4.Eta()
+            ZCand_rapidity[iZ] = aZ.p4.Rapidity()
+            ZCand_phi[iZ] = aZ.p4.Phi()
+            ZCand_flav[iZ] = aZ.finalState()
+            ZCand_l1Idx[iZ] = aZ.l1Idx
+            ZCand_l2Idx[iZ] = aZ.l2Idx
+            ZCand_fsr1Idx[iZ] = aZ.fsr1Idx
+            ZCand_fsr2Idx[iZ] = aZ.fsr2Idx
 
         self.out.fillBranch("ZCand_mass", ZCand_mass)
         self.out.fillBranch("ZCand_pt", ZCand_pt)
         self.out.fillBranch("ZCand_eta", ZCand_eta)
+        self.out.fillBranch("ZCand_rapidity", ZCand_rapidity)
         self.out.fillBranch("ZCand_phi", ZCand_phi)
         self.out.fillBranch("ZCand_flav", ZCand_flav)
         self.out.fillBranch("ZCand_l1Idx", ZCand_l1Idx)
@@ -463,6 +468,7 @@ class ZZFiller(Module):
             ZLLCand_massPreFSR = [0.]*len(ZLLs)
             ZLLCand_pt     = [0.]*len(ZLLs)
             ZLLCand_eta    = [0.]*len(ZLLs)
+            ZLLCand_rapidity = [0.]*len(ZLLs)
             ZLLCand_phi    = [0.]*len(ZLLs)
             ZLLCand_Z1mass = [0.]*len(ZLLs)
             ZLLCand_Z1flav = [0.]*len(ZLLs)
@@ -479,6 +485,7 @@ class ZZFiller(Module):
                 ZLLCand_massPreFSR[iZLL] = ZLL.massPreFSR()
                 ZLLCand_pt[iZLL] = ZLL.p4.Pt()
                 ZLLCand_eta[iZLL] = ZLL.p4.Eta()
+                ZLLCand_rapidity[iZLL] = ZLL.p4.Rapidity()
                 ZLLCand_phi[iZLL] = ZLL.p4.Phi()
                 ZLLCand_Z1mass[iZLL] = ZLL.Z1.M
                 ZLLCand_Z1flav[iZLL] = ZLL.Z1.finalState()
@@ -494,6 +501,7 @@ class ZZFiller(Module):
             self.out.fillBranch("ZLLCand_massPreFSR",   ZLLCand_massPreFSR)
             self.out.fillBranch("ZLLCand_pt",     ZLLCand_pt)
             self.out.fillBranch("ZLLCand_eta",    ZLLCand_eta)
+            self.out.fillBranch("ZLLCand_rapidity",    ZLLCand_rapidity)
             self.out.fillBranch("ZLLCand_phi",    ZLLCand_phi)
             self.out.fillBranch("ZLLCand_Z1mass", ZLLCand_Z1mass)
             self.out.fillBranch("ZLLCand_Z1flav", ZLLCand_Z1flav)

--- a/NanoAnalysis/python/ZZFiller.py
+++ b/NanoAnalysis/python/ZZFiller.py
@@ -360,10 +360,10 @@ class ZZFiller(Module):
         ZCand_rapidity = [0.]*len(SRZs)
         ZCand_phi = [0.]*len(SRZs)
         ZCand_flav = [0.]*len(SRZs)
-        ZCand_l1Idx = [0.]*len(SRZs)
-        ZCand_l2Idx = [0.]*len(SRZs)
-        ZCand_fsr1Idx = [0.]*len(SRZs)
-        ZCand_fsr2Idx = [0.]*len(SRZs)
+        ZCand_l1Idx = [-1]*len(SRZs)
+        ZCand_l2Idx = [-1]*len(SRZs)
+        ZCand_fsr1Idx = [-1]*len(SRZs)
+        ZCand_fsr2Idx = [-1]*len(SRZs)
 
         for iZ, aZ in enumerate(SRZs) :
             ZCand_mass[iZ] = aZ.p4.M()


### PR DESCRIPTION
Creation of `_pt`, `_eta`, `_rapidity`, `_phi` observables for the ZZ candidates and CRs ZL(L) candidates.

@namapane shall we initialize [these lists](https://github.com/CJLST/ZZAnalysis/blob/dev_RecoZObs/NanoAnalysis/python/ZZFiller.py#L355-363) with the length of the `SRZs` candidates (so `[0.]*len(SRZs)` instead of empty lists of length 0, `[]`)? If so, I can push another commit (adding also the rapidity to the CRs, since I just noticed I forgot about it).