### PR TITLE
fix muons for Z+X

### DIFF
--- a/AnalysisStep/test/ZpXEstimation/NanoConverter.py
+++ b/AnalysisStep/test/ZpXEstimation/NanoConverter.py
@@ -46,7 +46,7 @@ def makeCR(_df, _flag):
                                                    .Define('Leptons_id', "concatenate(Electron_pdgId,Muon_pdgId)")
                                                    .Define('Leptons_sip', "concatenate(Electron_sip3d,Muon_sip3d)")
                                                    .Define('Leptons_iso', "concatenate(Electron_pfRelIso03FsrCorr,Muon_pfRelIso03FsrCorr)")
-                                                   .Define('Leptons_isid', "concatenate(Electron_passBDT,Muon_ZZFullId)")
+                                                   .Define('Leptons_isid', "concatenate(Electron_passBDT,Muon_passID)")
                                                    ## Need to add the LepMissingHit branch for SS FR method
                                                    ## First create a dummy branch for muons filled with zeroes
                                                    .Define('Muon_lostHits', "addDummyBranch(Muon_pt)")
@@ -242,7 +242,7 @@ df_SR = ( df.Filter('bestCandIdx>=0').Define("ZZMass", "ZZCand_mass[bestCandIdx]
                                      .Define('Leptons_id', "concatenate(Electron_pdgId,Muon_pdgId)")
                                      .Define('Leptons_sip', "concatenate(Electron_sip3d,Muon_sip3d)")
                                      .Define('Leptons_iso', "concatenate(Electron_pfRelIso03FsrCorr,Muon_pfRelIso03FsrCorr)")
-                                     .Define('Leptons_isid', "concatenate(Electron_passBDT,Muon_ZZFullId)")
+                                     .Define('Leptons_isid', "concatenate(Electron_passBDT,Muon_passID)")
                                      ## Need to add the LepMissingHit branch for SS FR method
                                      ## First create a dummy branch for muons filled with zeroes
                                      .Define('Muon_lostHits', "addDummyBranch(Muon_pt)")
@@ -291,7 +291,7 @@ if not opt.SKIPZL:
                                            .Define('Leptons_id', "concatenate(Electron_pdgId,Muon_pdgId)")
                                            .Define('Leptons_sip', "concatenate(Electron_sip3d,Muon_sip3d)")
                                            .Define('Leptons_iso', "concatenate(Electron_pfRelIso03FsrCorr,Muon_pfRelIso03FsrCorr)")
-                                           .Define('Leptons_isid', "concatenate(Electron_passBDT,Muon_ZZFullId)")
+                                           .Define('Leptons_isid', "concatenate(Electron_passBDT,Muon_passID)")
                                            ## Need to add the LepMissingHit branch for SS FR method
                                            ## First create a dummy branch for muons filled with zeroes
                                            .Define('Muon_lostHits', "addDummyBranch(Muon_pt)")

--- a/NanoAnalysis/python/lepFiller.py
+++ b/NanoAnalysis/python/lepFiller.py
@@ -20,6 +20,7 @@ class lepFiller(Module):
         self.eleRelaxedIdNoSIP = cuts["eleRelaxedIdNoSIP"]
         self.eleFullId = cuts["eleFullId"]
         self.eleFullIdNoSIP = cuts["eleFullIdNoSIP"]
+        self.passMuID = cuts["passMuID"]
         self.muRelaxedId = cuts["muRelaxedId"]
         self.muRelaxedIdNoSIP = cuts["muRelaxedIdNoSIP"]
         self.muFullId = cuts["muFullId"]
@@ -42,6 +43,7 @@ class lepFiller(Module):
         self.out.branch("Electron_pfRelIso03FsrCorr", "F", lenVar="nElectron", title="FSR-subtracted pfRelIso03")
         self.out.branch("Electron_passIso", "O", lenVar="nElectron", title="always True for electrons")
 
+        self.out.branch("Muon_passID", "O", lenVar="nMuon" , title="pass H4l muon ID")
         self.out.branch("Muon_ZZFullSel", "O", lenVar="nMuon" , title="pass H4l full SR selection (FullID + isolation)")
         self.out.branch("Muon_ZZFullId", "O", lenVar="nMuon", title="pass H4l full ID selection")
         self.out.branch("Muon_ZZFullSelNoSIP", "O", lenVar="nMuon", title="pass H4l full ID without SIP (base for CR SIP  method)")
@@ -72,6 +74,7 @@ class lepFiller(Module):
 
         # IDs (no iso)
         eleBDT = list(self.passEleBDT(e) for e in electrons)
+        muID = list(self.passMuID(m) for m in muons)
         eleRelaxedId = list(self.eleRelaxedId(e) for e in electrons)
         muRelaxedId = list(self.muRelaxedId(m) for m in muons)
         eleRelaxedIdNoSIP = list(self.eleRelaxedIdNoSIP(e) for e in electrons)
@@ -172,6 +175,7 @@ class lepFiller(Module):
         self.out.fillBranch("Electron_pfRelIso03FsrCorr", ele_isoFsrCorr)
         self.out.fillBranch("Electron_passIso", ele_passIso)
 
+        self.out.fillBranch("Muon_passID", muID)
         self.out.fillBranch("Muon_ZZFullSel", muFullSel)
         self.out.fillBranch("Muon_ZZFullId", muFullId)
         self.out.fillBranch("Muon_ZZRelaxedId", muRelaxedId)

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -77,6 +77,8 @@ cuts = dict(
 
     passEleBDT = getEleBDTCut(LEPTON_SETUP, DATA_TAG, NANOVERSION),
 
+    passMuID = (lambda l: (l.isPFcand or (l.highPtId>0 and l.pt>200.))),
+
     # Relaxed IDs used for CRs for fake rate method
     muRelaxedId  = (lambda l : cuts["muRelaxedIdNoSIP"](l) and abs(l.sip3d) < cuts["sip3d"]),
     eleRelaxedId = (lambda l : cuts["eleRelaxedIdNoSIP"](l) and abs(l.sip3d) < cuts["sip3d"]),


### PR DESCRIPTION
Bug fixing for the branch LepisID in the NanoAODConverter
I was saving Muon_ZZFullId in the LepisID branch, but this is actually ID+SIP+pT+eta+dx+dxy.
LepisID is supposed to have only the pure ID:  (l.isPFcand or (l.highPtId>0 and l.pt>200.))
Added a new branch with this information (similar to what is done for the Electron_passBDT branch)