### PR TITLE
Use raw_input() instead of input() in python2 for batch_Condor.py

### DIFF
--- a/AnalysisStep/scripts/batch_Condor.py
+++ b/AnalysisStep/scripts/batch_Condor.py
@@ -15,6 +15,8 @@ from optparse import OptionParser
 from ZZAnalysis.AnalysisStep.eostools import *
 from ZZAnalysis.AnalysisStep.readSampleInfo import *
 
+if(sys.version_info.major < 3):
+    input = raw_input
 
 def chunks(l, n):
     return [l[i:i+n] for i in range(0, len(l), n)]


### PR DESCRIPTION
This fixes commit 56aa8c1a2e7874dcbb1057657153e4f1179dbf86 which adapts the script to run on python3.
This fix is needed if the goal is to maintain compatibility with python2, as seem to be indicated by the fact that the shebang is still `/bin/env python` instead of `/bin/env python3` and `print_function` is imported.