### PR TITLE
Add protection for cases where the checkout recipe has changed and git pull is not enough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Pdfdata
 br.sm?
 input.DAT
 ffwarn.dat
+AnalysisStep/data/checkoutId

--- a/AnalysisStep/python/validateCheckout.py
+++ b/AnalysisStep/python/validateCheckout.py
@@ -1,0 +1,35 @@
+#!/bin/env python3
+# Implement a check to detect cases where user has pulled the working
+# area without realizing that the checkout recipe was changed.
+#
+# It is intended to be run the first time by the checkout script, so that it
+# stores the git commit ID of the script itself.
+#
+import subprocess
+import os
+
+def validateCheckout() :
+    oldrev = None
+    path = os.environ['CMSSW_BASE'] + "/src/ZZAnalysis/"
+    gitrev = (subprocess.check_output(['git', "log", "-n 1", "--format=%h", "checkout_13X.csh"], cwd=path)).decode('utf-8').rstrip()
+
+    idfile=path+"AnalysisStep/data/checkoutId"
+    if os.path.isfile(idfile) :
+        f = open(idfile, 'r')
+        oldrev = f.read()
+        f.close()
+        if oldrev != gitrev :
+            print("Warning: the ZZAnalysis working area has been pulled, but the checkout recipe was udpated upstream since the area was checked out. (diffs:", oldrev+".."+gitrev+")\nPlease re-create the working area.")
+            return False
+        else:
+            return True
+    else:
+        print("Checkout recipe version is:", gitrev)
+        f = open(idfile, 'w')
+        f.write(gitrev)
+        f.close()
+        return True
+    
+ret = validateCheckout()
+if not ret:
+    exit(1)

--- a/AnalysisStep/scripts/batch_Condor.py
+++ b/AnalysisStep/scripts/batch_Condor.py
@@ -15,6 +15,7 @@ from datetime import date
 from optparse import OptionParser
 from ZZAnalysis.AnalysisStep.eostools import *
 from ZZAnalysis.AnalysisStep.readSampleInfo import *
+from ZZAnalysis.AnalysisStep.validateCheckout import validateCheckout 
 
 
 def chunks(l, n):
@@ -560,6 +561,10 @@ class Component(object):
         
       
 if __name__ == '__main__':
+    # Check that the checkout recipe has been properly updated 
+    if not validateCheckout() :
+        exit(1)
+
     batchManager = MyBatchManager()
     
     cfgFileName = batchManager.options_.cfgFileName # This is the python job config.

--- a/NanoAnalysis/test/runLocal.py
+++ b/NanoAnalysis/test/runLocal.py
@@ -7,6 +7,11 @@
 from __future__ import print_function
 from ZZAnalysis.NanoAnalysis.tools import setConf, getConf, insertAfter
 
+# Check that the checkout recipe has been properly updated 
+from ZZAnalysis.AnalysisStep.validateCheckout import validateCheckout 
+if not validateCheckout() :
+    exit(1)
+
 #SampleToRun = "MCsync_Rereco"
 #SampleToRun = "MCsync_UL"
 #SampleToRun = "Data2022"

--- a/checkout_13X.csh
+++ b/checkout_13X.csh
@@ -68,7 +68,7 @@ sed -i '/#include "RooMinuit.h"/d' KinZfitter/KinZfitter/interface/KinZfitter.h
 git cms-addpkg PhysicsTools/NanoAOD
 git cms-cherry-pick-pr 43536 CMSSW_13_0_X
 
-#Pick more fixes in NanoAODTools (support for "S" branch types); in release since 13_3_18, 14_0_0, 14_1_0
+#Pick more fixes in NanoAODTools (support for "S" branch types); in release since 14_0_0, 14_1_0; queued in 13_3_X (X>3)
 git cms-addpkg PhysicsTools/NanoAODTools
 git fetch https://github.com/namapane/cmssw.git NAT-dev:namapane_NAT-dev
 git cherry-pick 3e73ca4c2f8
@@ -85,3 +85,5 @@ git clone https://github.com/cms-cat/nanoAOD-tools-modules.git PhysicsTools/NATM
 #Now we can compile everything
 scram b -j4
 
+#Set up protection for user pulling but missing that this recipe has been updated
+python3 ZZAnalysis/AnalysisStep/python/validateCheckout.py


### PR DESCRIPTION
This sets up a mechanism to warn users who have made a git pull and did not realize that the checkout recipe was updated (and so recreating the working area is necessary).
This is in preparation for a switch to 13_3_3.