### PR TITLE
Move SF weights to ZZExtraFiller and extend it to CRs

### DIFF
--- a/NanoAnalysis/python/ZZExtraFiller.py
+++ b/NanoAnalysis/python/ZZExtraFiller.py
@@ -4,10 +4,7 @@
 # -extra Zs
 #
 # TODO:
-# -generalize to add the same quantities for CRs (ZLLCand) (move actual code into a function to be called for each candidate)
 # -add other categorization variables (MELA discriminants besides KD, etc)
-# -move here the computation of data/MC scale factors here from ZZFiller,
-# so that it is not called for the whole combinatorial
 #
 ###
 
@@ -15,54 +12,95 @@ from __future__ import print_function
 from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
 #from PhysicsTools.NanoAODTools.postprocessing.tools import deltaR
+from ROOT import LeptonSFHelper
 
 class ZZExtraFiller(Module):
-    def __init__(self, region):
-        print("***ZZExtraFiller", flush=True)
-        self.region = region
+    def __init__(self, isMC, year, data_tag, processCR):
+        print("***ZZExtraFiller: isMC:", isMC, "year:", year, "data_tag:", data_tag, flush=True)
+        self.isMC = isMC
+        self.processCR = processCR
+        self.year = year
+        if isMC:
+            self.lepSFHelper = LeptonSFHelper(data_tag)
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
-        self.out.branch("ZZCand_nExtraLep", "I", lenVar="nZZCand", title="number of extra leptons passing H4l full sel")
-        self.out.branch("ZZCand_nExtraZ", "I", lenVar="nZZCand", title="number of extra Zs passing H4l full sel")
+        self.bookExtra("ZZCand")
+        if self.processCR :
+            self.bookExtra("ZLLCand")
 
-    def analyze(self, event):
-        ZZs = Collection(event, 'ZZCand')
-        Zs = Collection(event, 'ZCand')
+    def bookExtra(self, collName) :
+        theLenVar="n"+collName
+        self.out.branch(collName+"_nExtraLep", "I", lenVar=theLenVar, title="number of extra leptons passing H4l full sel")
+        self.out.branch(collName+"_nExtraZ", "I", lenVar=theLenVar, title="number of extra Zs passing H4l full sel")
+        if self.isMC:
+            self.out.branch(collName+"_dataMCWeight", "F", lenVar=theLenVar, title="data/MC efficiency correction weight")
+
+    def analyze(self, event) :
         electrons = Collection(event, "Electron")
         muons = Collection(event, "Muon")
-        leps = list(electrons) + list(muons)
-        nlep=len(leps)
+        self.leps = list(electrons) + list(muons)
+        self.Zs = Collection(event, 'ZCand')
 
-        candIdx = event.bestCandIdx
-        if candIdx <0: return True
-        theZZ = ZZs[candIdx]        
-        theZZleps = [theZZ.Z1l1Idx, theZZ.Z1l2Idx, theZZ.Z2l1Idx, theZZ.Z2l2Idx]
-
-        # Extra leps
-        extraLeps = []
-        for i in range(nlep) :
- #           print(i, leps[i].pt, leps[i].ZZFullSel)
-            if i in theZZleps : continue
-            if leps[i].ZZFullSel : extraLeps.append(i)
-
-#        print("---ZZLeps:", theZZleps)
-#        print(extraLeps)
-
-        # Extra Zs
-        extraZs = []
-        for iZ, Z in enumerate(Zs) :
-            if Z.l1Idx in theZZleps or Z.l2Idx in theZZleps : continue
-            extraZs.append(iZ)
-
-        # Store the result as a collection variable, even if it is filled only for the best candidate
-        nExtraLepsA = [-1]*event.nZZCand
-        nExtraZsA = [-1]*event.nZZCand
-        nExtraLepsA[candIdx] = len(extraLeps)
-        nExtraZsA[candIdx] = len(extraZs)
-        
-        self.out.fillBranch("ZZCand_nExtraLep", nExtraLepsA)
-        self.out.fillBranch("ZZCand_nExtraZ", nExtraZsA)
-
+        self.addExtra('ZZCand', event)
+        if self.processCR :
+            self.addExtra('ZLLCand', event)
 
         return True
+
+    def addExtra(self, collName, event) :
+        cands = Collection(event, collName)
+
+        nExtraLeps = [-1]*len(cands)
+        nExtraZs = [-1]*len(cands)
+        wDataMC = [-1]*len(cands)
+        for iCand, aCand in enumerate(cands):
+            theCandLepIdxs = [aCand.Z1l1Idx, aCand.Z1l2Idx, aCand.Z2l1Idx, aCand.Z2l2Idx]
+
+            # Extra leps
+            extraLeps = []
+            for i in range(len(self.leps)) :
+                if i in theCandLepIdxs : continue
+                if self.leps[i].ZZFullSel : extraLeps.append(i)
+
+            # Extra Zs
+            extraZs = []
+            for iZ, Z in enumerate(self.Zs) :
+                if Z.l1Idx in theCandLepIdxs or Z.l2Idx in theCandLepIdxs : continue
+                extraZs.append(iZ)
+            nExtraLeps[iCand] = len(extraLeps)
+            nExtraZs[iCand] = len(extraZs)
+
+            if self.isMC:
+                theCandLeps = [self.leps[i] for i in theCandLepIdxs] 
+                wDataMC[iCand] = self.getDataMCWeight(theCandLeps)
+        
+        self.out.fillBranch(collName+"_nExtraLep", nExtraLeps)
+        self.out.fillBranch(collName+"_nExtraZ", nExtraZs)
+        if self.isMC:
+            self.out.fillBranch(collName+"_dataMCWeight", wDataMC)
+
+
+    ### Compute lepton efficiency scale factor
+    def getDataMCWeight(self, leps) :
+        if self.year >= 2023 : #FIXME: not yet implemented
+            return 1.
+        dataMCWeight = 1.
+        for lep in leps:
+            myLepID = abs(lep.pdgId)
+            mySCeta = lep.eta
+            isCrack = False # FIXME: isGap() is not available in nanoAODs, and cannot be recomputed easily based on eta, phi. We thus use the non-gap SFs for all electrons.
+            if myLepID==11 :
+                mySCeta = lep.eta + lep.deltaEtaSC    
+
+            # Deal with very rare cases when SCeta is out of 2.5 bounds
+            mySCeta = min(mySCeta,2.49)
+            mySCeta = max(mySCeta,-2.49)
+
+            SF = self.lepSFHelper.getSF(self.year, myLepID, lep.pt, lep.eta, mySCeta, isCrack)
+#            SF_Unc = self.lepSFHelper.getSFError(year, myLepID, lep.pt, lep.eta, mySCeta, isCrack)
+            dataMCWeight *= SF
+
+        return dataMCWeight
+
+        

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -132,7 +132,7 @@ if not IsMC :
 reco_sequence = [lepFiller(cuts, LEPTON_SETUP), # FSR and FSR-corrected iso; flags for passing IDs
                  ZZFiller(runMELA, bestCandByMELA, IsMC, LEPTON_SETUP, PROCESS_CR, DATA_TAG, addZL=PROCESS_ZL, debug=DEBUG), # Build ZZ candidates; choose best candidate; filter events with candidates
                  jetFiller(), # Jets cleaning with leptons
-                 ZZExtraFiller('SR'), # Add information on extra objects to the selected best candidate
+                 ZZExtraFiller(IsMC, LEPTON_SETUP, DATA_TAG, PROCESS_CR), # Additional variables to selected candidates
                  # MELAFiller(), # Compute the full set of discriminants for the best candidate
                  ]
 


### PR DESCRIPTION
- Move computation of SF weights to ZZExtraFiller so that they are computed only for selected candidates and not for the full combinatorial, and also to prepare for getting corrections from correctionlib modules (eg. [(muonSF.py)](https://github.com/cms-cat/nanoAOD-tools-modules/blob/master/python/modules/muonSF.py)), which will be inserted between ZZFiller and ZZExtraFIller it in the sequence. 
- Generalize ZZExtraFiller so that it runs for both the SR and CRs.