### PR TITLE
Use uncorrected pt for ele BDT cut

### DIFF
--- a/AnalysisStep/scripts/batch_Condor.py
+++ b/AnalysisStep/scripts/batch_Condor.py
@@ -82,6 +82,8 @@ if [ -z $cmsRunStatus ]; then cmsRunStatus=0; fi
 echo 'cmsRun done at: ' $(date) with exit status: $cmsRunStatus
 gzip log.txt
 
+set +euo pipefail
+
 export ROOT_HIST=0
 if [ -s ZZ4lAnalysis.root ]; then
  root -q -b '${{CMSSW_BASE}}/src/ZZAnalysis/AnalysisStep/test/prod/rootFileIntegrity.r("ZZ4lAnalysis.root")'
@@ -91,8 +93,6 @@ elif [ -f  ZZ4lAnalysis.root ]; then
 else
  echo ERROR: ZZ4lAnalysis.root file is missing
 fi
-
-set +euo pipefail
 
 echo "Files on node:"
 ls -la
@@ -150,6 +150,8 @@ echo path: `pwd`
 exitStatus=   #default for successful completion is an empty file
 python3 run_cfg.py >& log.txt || exitStatus=$?
 
+set +euo pipefail
+
 echo -n $exitStatus > exitStatus.txt
 if [ -z $exitStatus ]; then exitStatus=0; fi
 echo 'job done at: ' $(date) with exit status: $exitStatus
@@ -164,8 +166,6 @@ elif [ -f  ZZ4lAnalysis.root ]; then
 else
  echo ERROR: ZZ4lAnalysis.root file is missing
 fi
-
-set +euo pipefail
 
 echo "Files on node:"
 ls -la

--- a/NanoAnalysis/python/ZZFiller.py
+++ b/NanoAnalysis/python/ZZFiller.py
@@ -64,7 +64,7 @@ class ZZFiller(Module):
         self.ZmassValue = 91.1876;
 
         self.candsToStore = StoreOption.BestCandOnly # Only store the best candidate for the SR
-
+#        self.candsToStore = StoreOption.AllWithRelaxedMuId # Use this for ID optimization studies
 
         # Pre-selection of leptons to build Z and LL candidates.
         # Normally it is the full ID + iso if only the SR is considered, or the relaxed ID if CRs are also filled,
@@ -94,12 +94,16 @@ class ZZFiller(Module):
                           dict(name="isGlobal", sel=lambda l : l.isGlobal),  # Note: this is looser than nanoAOD presel.
                           dict(name="isTracker", sel=lambda l : l.isTracker),# Note: this is looser than nanoAOD presel.
                           dict(name="isTrackerArb", sel=lambda l : l.isTracker and l.nStations>0), # Arbitrated tracker muon. Note: this is looser than nanoAOD presel.
+                          dict(name="inTimeMuon", sel=lambda l : l.inTimeMuon), # 
                           ]
 
             # Add variable to store the worst value of a given quantity among the 4 leptons of a candidate, for optimization studies.
             # Worst is intended as lowest value (as for an MVA), unless the variable's name starts with "max".
             self.muonIDVars=[dict(name="maxsip3d", sel=lambda l : l.sip3d if (abs(l.dxy)<0.5 and abs(l.dz) < 1) else 999.), # dxy, dz cuts included with SIP
                              dict(name="maxpfRelIso03FsrCorr", sel=lambda l : l.pfRelIso03FsrCorr),
+                             dict(name="maxminiPFRelIso_all", sel=lambda l : l.miniPFRelIso_all),
+                             # Can also try: puppiIsoId, multiIsoId
+                             dict(name="mvaMuID", sel=lambda l : l.mvaMuID if (l.looseId and l.sip3d<4. and l.dxy<0.5 and l.dz < 1) else -2.), # additional presel required?
                              dict(name="mvaLowPt", sel=lambda l : l.mvaLowPt if (l.looseId and l.sip3d<4. and l.dxy<0.5 and l.dz < 1) else -2.), # additional presel required, cf: https://cmssdt.cern.ch/dxr/CMSSW/source/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc#1027-1046
                              ]
         if self.runMELA :

--- a/NanoAnalysis/python/getEleBDTCut.py
+++ b/NanoAnalysis/python/getEleBDTCut.py
@@ -5,7 +5,7 @@
 # - nanoAOD version (9, ecc)
 ##
 
-def getEleBDTCut(era, dataTag, nanoVersion) :
+def getEleBDTCut(era, dataTag, nanoVersion, useUncorrPt=False) :
     # nanoAODv9 includes mvaFall17V2Iso = 2017 WP and training (ElectronMVAEstimatorRun2Fall17IsoV2Values)
 
     def eleBDTCut_RunIIpreUL_v9(ele) :
@@ -31,15 +31,21 @@ def getEleBDTCut(era, dataTag, nanoVersion) :
                                      (fSCeta>=1.479                and BDT > -0.5532483665)))
 
 
-    def eleBDTCut_RunIII_ULTraining(ele) :
-        fSCeta = abs(ele.eta + ele.deltaEtaSC)
-        BDT = ele.mvaHZZIso #In Run3 samples: 2018 UL tuning (ElectronMVAEstimatorRun2Summer18ULIdIsoValues)
-        return (ele.pt<=10. and     ((fSCeta<0.8                   and BDT > 0.9044286167) or \
-                                     (fSCeta>=0.8 and fSCeta<1.479 and BDT > 0.9094166886) or \
-                                     (fSCeta>=1.479                and BDT > 0.9443653660))) \
-                or (ele.pt>10. and  ((fSCeta<0.8                   and BDT > 0.1968600840) or \
-                                     (fSCeta>=0.8 and fSCeta<1.479 and BDT > 0.0759172100) or \
-                                     (fSCeta>=1.479                and BDT > -0.5169136775)))
+    # Run3 nanoAODv12 samples have the 2018 UL tuning (ElectronMVAEstimatorRun2Summer18ULIdIsoValues)
+    # The WP was derived before scale corrections, so the uncorrected pt should be used when available.
+    def eleBDTCut_RunIII_ULTraining_def(ele) :
+        return(eleBDTCut_RunIII_ULTraining(ele.pt, abs(ele.eta + ele.deltaEtaSC), ele.mvaHZZIso))
+        
+    def eleBDTCut_RunIII_ULTraining_uncorr(ele) :
+        return(eleBDTCut_RunIII_ULTraining(ele.uncorrected_pt, abs(ele.eta + ele.deltaEtaSC), ele.mvaHZZIso))
+               
+    def eleBDTCut_RunIII_ULTraining(pt, fSCeta, BDT) :
+        return (pt<=10. and     ((fSCeta<0.8                   and BDT > 0.9044286167) or \
+                                 (fSCeta>=0.8 and fSCeta<1.479 and BDT > 0.9094166886) or \
+                                 (fSCeta>=1.479                and BDT > 0.9443653660))) \
+               or (pt>10. and  ((fSCeta<0.8                   and BDT > 0.1968600840) or \
+                                (fSCeta>=0.8 and fSCeta<1.479 and BDT > 0.0759172100) or \
+                                (fSCeta>=1.479                and BDT > -0.5169136775)))
 
     if era == 2017 or era == 2018 :
         if "UL" in dataTag :
@@ -50,7 +56,11 @@ def getEleBDTCut(era, dataTag, nanoVersion) :
                 return eleBDTCut_RunIIpreUL_v9
 
     elif era >=2022 :
-        return eleBDTCut_RunIII_ULTraining
+        if useUncorrPt:
+            print("unc")
+            return eleBDTCut_RunIII_ULTraining_uncorr
+        else :
+            return eleBDTCut_RunIII_ULTraining_def
 
     # Fallback: combination not supported
     raise ValueError('getEleBDTCut: era '+ str(era)+', dataTag ' + dataTag + ', nanoVersion ' + nanoVersion + ' not supported')

--- a/NanoAnalysis/python/modules/puWeightProducer.py
+++ b/NanoAnalysis/python/modules/puWeightProducer.py
@@ -2,7 +2,7 @@
 # Imported from the standalone version of PhysicsTools.NanoAODTools.postprocessing.modules.common.
 #
 # NOTE: The helpers at the end set up the new correctionlib-based module from
-# PhysicsTools/NATModusles.
+# PhysicsTools/NATModules.
 
 from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
 from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -80,7 +80,7 @@ cuts = dict(
                                      and abs(l.dxy) < cuts["dxy"]
                                      and abs(l.dz) < cuts["dz"])),
 
-    passEleBDT = getEleBDTCut(LEPTON_SETUP, DATA_TAG, NANOVERSION),
+    passEleBDT = getEleBDTCut(LEPTON_SETUP, DATA_TAG, NANOVERSION, APPLYELECORR),
 
     passMuID = (lambda l: (l.isPFcand or (l.highPtId>0 and l.pt>200.))),
 
@@ -156,7 +156,7 @@ if APPLYMUCORR :
         from ZZAnalysis.NanoAnalysis.modules.muonScaleResProducer import getMuonScaleRes
         insertBefore(reco_sequence, 'lepFiller', getMuonScaleRes(LEPTON_SETUP, DATA_TAG, IsMC, overwritePt=True))
         
-# Add ele scale corrections for Run 3. It should be applied after passBDT is checked, but before running ZZFiller
+# Add ele scale corrections for Run 3
 if APPLYELECORR and LEPTON_SETUP >=2022 :
     from ZZAnalysis.NanoAnalysis.modules.eleScaleResProducer import getEleScaleRes
     insertBefore(reco_sequence, 'lepFiller', getEleScaleRes(LEPTON_SETUP, DATA_TAG, IsMC, overwritePt=True))


### PR DESCRIPTION
...as the BDT WP was set on uncorrected pT, for consistency (although it makes practically no difference in real life).

Also includes some minor changes (protect for some fancy cases in batch scripts, etc)