### PR TITLE
Re-introduce the fix for haddnano.py in the checkout recipe

### DIFF
--- a/checkout_13X.csh
+++ b/checkout_13X.csh
@@ -64,6 +64,10 @@ sed -i '/SimTracker\/Records/d' KinZfitter/HelperFunction/BuildFile.xml
 sed -i '/SimTracker\/Records/d' KinZfitter/KinZfitter/BuildFile.xml
 sed -i '/#include "RooMinuit.h"/d' KinZfitter/KinZfitter/interface/KinZfitter.h
 
+#Pick the fix from #43536 (haddNano.py); in release since 13_0_18, 14_0_2, 14_1_0; it was not backported to 13_3_X
+git cms-addpkg PhysicsTools/NanoAOD
+git cms-cherry-pick-pr 43536 CMSSW_13_0_X
+
 #Pick more fixes in NanoAODTools (support for "S" branch types); in release since 14_0_0, 14_1_0; queued in 13_3_X (X>3)
 git cms-addpkg PhysicsTools/NanoAODTools
 git fetch https://github.com/namapane/cmssw.git NAT-dev:namapane_NAT-dev


### PR DESCRIPTION
This patch was backported to 13_0_X and 13_1_X, but not to 13_3_X, so it must be kept in the recipe.