### PR TITLE
Support production in a el9 Singularity container

### DIFF
--- a/AnalysisStep/scripts/batch_Condor.py
+++ b/AnalysisStep/scripts/batch_Condor.py
@@ -155,6 +155,8 @@ if [ -z $exitStatus ]; then exitStatus=0; fi
 echo 'job done at: ' $(date) with exit status: $exitStatus
 gzip log.txt
 
+set +euo pipefail
+
 export ROOT_HIST=0
 if [ -s ZZ4lAnalysis.root ]; then
  root -q -b '${{CMSSW_BASE}}/src/ZZAnalysis/AnalysisStep/test/prod/rootFileIntegrity.r("ZZ4lAnalysis.root")'
@@ -164,8 +166,6 @@ elif [ -f  ZZ4lAnalysis.root ]; then
 else
  echo ERROR: ZZ4lAnalysis.root file is missing
 fi
-
-set +euo pipefail
 
 echo "Files on node:"
 ls -la
@@ -229,7 +229,7 @@ periodic_remove         = JobStatus == 5
    release=open('/etc/redhat-release','r').read()
    req = ""
    if "release 7" in release:
-       req = "requirements = (OpSysAndVer =?= \"CentOS7\")"
+       req = "MY.SingularityImage = \"/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/cms-cat/cmssw-lxplus/cmssw-el7-lxplus:latest/\""
    elif "release 8" in release: #use a Singularity container
        req = "MY.WantOS = \"el8\""
    elif "release 9" in release:

--- a/README.md
+++ b/README.md
@@ -9,15 +9,20 @@ Used for analysis of 2016, 2017, and 2018 data
 
 Please use **CMSSW_10_6_30**. 
 
-Download and execute the setup script:
+Download and execute the setup script in a el7 Singularity container:
 ```
-wget -O ${TMPDIR}/checkout_10X.csh https://raw.githubusercontent.com/CJLST/ZZAnalysis/Run2UL_22/checkout_10X.csh
-cd $CMSSW_BASE/src
+cmssw-el7
+cmsrel CMSSW_10_6_30
+cd CMSSW_10_6_30/src
 cmsenv
-chmod u+x ${TMPDIR}/checkout_10X.csh
-${TMPDIR}/checkout_10X.csh
+wget -O ${TMPDIR}/checkout_10X.csh https://raw.githubusercontent.com/CJLST/ZZAnalysis/Run2UL_22/checkout.csh
+chmod u+x ${TMPDIR}/checkout.csh
+${TMPDIR}/checkout.csh
 scramv1 b -j 4
 ```
+
+Please use `ZZAnalysis/start_el7.sh` to open a slc7 container in new shells, in order to have access to the Condor queues.
+
 
 To update this package from the release
 ------------------------------------------

--- a/checkout_10X.csh
+++ b/checkout_10X.csh
@@ -1,13 +1,15 @@
 #!/bin/tcsh -fe
 #
 # Instructions:
-# wget -O ${TMPDIR}/checkout_10X.csh https://raw.githubusercontent.com/CJLST/ZZAnalysis/Run2UL_22/checkout_10X.csh
-# cd $CMSSW_BASE/src
+# cmssw-el7
+# cmsrel CMSSW_10_6_30
+# cd CMSSW_10_6_30/src
 # cmsenv
-# chmod u+x ${TMPDIR}/checkout_10X.csh
-# ${TMPDIR}/checkout_10X.csh
+# wget -O ${TMPDIR}/checkout_10X.csh https://raw.githubusercontent.com/CJLST/ZZAnalysis/Run2UL_22/checkout.csh
+# chmod u+x ${TMPDIR}/checkout.csh
+# ${TMPDIR}/checkout.csh
 
-############## For CMSSW_10_6_26
+############## For CMSSW_10_6_30
 git cms-init
 
 # New Jet PU ID: dedicated training for each year
@@ -85,3 +87,5 @@ git clone https://github.com/mhl0116/KinZfitter-1.git KinZfitter
 git clone https://github.com/cms-nanoAOD/nanoAOD-tools.git PhysicsTools/NanoAODTools
 (cd PhysicsTools/NanoAODTools ; git checkout -b from-c32f055 c32f055)
 
+echo
+echo "***Note: Please use ZZAnalysis/start_el7.sh to open a slc7 container in new shells, in order to have access to the Condor queues.***"

--- a/start_el7.sh
+++ b/start_el7.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# This script is imported from: https://gitlab.cern.ch/cms-cat/cmssw-lxplus
+
+export APPTAINER_BINDPATH=/afs,/cvmfs,/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security,/cvmfs/grid.cern.ch/etc/grid-security/vomses:/etc/vomses,/eos,/etc/pki/ca-trust,/etc/tnsnames.ora,/run/user,/tmp,/var/run/user,/etc/sysconfig,/etc:/orig/etc
+schedd=`myschedd show -j | jq .currentschedd | tr -d '"'`
+
+apptainer -s exec /cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/cms-cat/cmssw-lxplus/cmssw-el7-lxplus:latest/ sh -c "source /app/setupCondor.sh && export _condor_SCHEDD_HOST=$schedd && export _condor_SCHEDD_NAME=$schedd && export _condor_CREDD_HOST=$schedd && /bin/bash  "


### PR DESCRIPTION
This commit introduces a few changes to support running on el7 Singularity containers:

- New script [`start_el7.sh`](https://github.com/namapane/ZZAnalysis/blob/a12c220a5b88f397d284565c91e07356b627f50f/start_el7.sh), that should be used instead of cmssw-el7 to open a Condor-aware container
- Fix in batch_Condor.py to run jobs in the same container
- Fix in batch_Condor.py to fix an issue where some the log would be truncated for failing jobs when the -t option is used
- update README.md and doc