### PR TITLE
Fix batch_Condor.py

### DIFF
--- a/AnalysisStep/scripts/batch_Condor.py
+++ b/AnalysisStep/scripts/batch_Condor.py
@@ -82,6 +82,8 @@ if [ -z $cmsRunStatus ]; then cmsRunStatus=0; fi
 echo 'cmsRun done at: ' $(date) with exit status: $cmsRunStatus
 gzip log.txt
 
+set +euo pipefail
+
 export ROOT_HIST=0
 if [ -s ZZ4lAnalysis.root ]; then
  root -q -b '${{CMSSW_BASE}}/src/ZZAnalysis/AnalysisStep/test/prod/rootFileIntegrity.r("ZZ4lAnalysis.root")'
@@ -91,8 +93,6 @@ elif [ -f  ZZ4lAnalysis.root ]; then
 else
  echo ERROR: ZZ4lAnalysis.root file is missing
 fi
-
-set +euo pipefail
 
 echo "Files on node:"
 ls -la


### PR DESCRIPTION
Fix in batch_Condor.py to fix an issue where some the log would be truncated for failing jobs when the -t option is used.
This fix was mentioned in #269, but was not implemented correctly therein.