### PR TITLE
Prepare to switch to CMSSW_14_1_6

### DIFF
--- a/AnalysisStep/scripts/forcePrefetch.csh
+++ b/AnalysisStep/scripts/forcePrefetch.csh
@@ -1,0 +1,36 @@
+#!/bin/tcsh
+# Tweak miniAOD Condor jobs to pre-fetch the input files.
+# The prefetch is done with xrdcp using root://cms-xrd-global.cern.ch/
+# as a redirector.
+# Other options, depending of the region where the files are located:
+# root://cmsxrootd.fnal.gov/
+# root://xrootd-cms.infn.it/
+# Note: this is relevant only for jobs running on miniAODs, not for nanoAODs.
+# IMPORTANT: this should be used only for jobs created with the EOS transfer option (-t)
+# Usage: call forcePrefetch.csh from the folder containing Chunks.
+
+
+foreach f (./*Chunk*/run_cfg.py)
+echo "Forcing prefetch in " $f
+
+
+cat >> $f << EOF 
+
+# Remove the global redirector from the file name, in case it was specified
+for i,f in enumerate(process.source.fileNames) :
+  process.source.fileNames[i] = f.replace("root://cms-xrd-global.cern.ch/",'')
+
+import os
+for i,f in enumerate(process.source.fileNames) :
+  tempdir = "."
+  print("prefetching", f)
+  os.system("xrdcp -d 1 -f root://cms-xrd-global.cern.ch/"+f+" "+tempdir)
+  process.source.fileNames[i] = "file:"+tempdir+"/"+os.path.basename(f)
+print("New fileNames:")
+print(process.source.fileNames)
+
+EOF
+
+end
+
+

--- a/AnalysisStep/scripts/forceRedirector.csh
+++ b/AnalysisStep/scripts/forceRedirector.csh
@@ -1,5 +1,10 @@
 #!/bin/tcsh
-
+# Tweak miniAOD Condor jobs to use the global redirector for xrootd acces.
+# Other options, depending of the region where the files are located:
+# root://cmsxrootd.fnal.gov/ 
+# root://xrootd-cms.infn.it/
+# Note: this is relevant only for jobs running on miniAODs, not for nanoAODs.
+# Usage: call forceRedirector.csh from the folder containing Chunks.
 
 foreach f (./*Chunk*/run_cfg.py)
 echo "Forcing global redirector in " $f

--- a/checkout_13X.csh
+++ b/checkout_13X.csh
@@ -7,7 +7,7 @@
 # chmod u+x ${TMPDIR}/checkout.csh
 # ${TMPDIR}/checkout.csh
 
-############## For CMSSW_13_3_3
+############## For CMSSW_13_3_3 (2022 data/MC) or CMSSW_14_1_6 (2023 data/MC)
 
 #exit when any command fails
 set -e
@@ -58,25 +58,28 @@ ln -s ${CMSSW_BASE}/src/JHUGenMELA/MELA/data/*/*.so \
       ${CMSSW_BASE}/src/MelaAnalytics/EventContainer/lib/*.so \
       ${CMSSW_BASE}/lib/${SCRAM_ARCH}
 
-#kinematic refitting (obsolete?)
+#kinematic refitting
 git clone https://github.com/ferrico/KinZfitter.git KinZfitter
 (cd KinZfitter ; git checkout -b from-f781891 f781891)
 sed -i '/SimTracker\/Records/d' KinZfitter/HelperFunction/BuildFile.xml
 sed -i '/SimTracker\/Records/d' KinZfitter/KinZfitter/BuildFile.xml
 sed -i '/#include "RooMinuit.h"/d' KinZfitter/KinZfitter/interface/KinZfitter.h
 
-#Pick the fix from #43536 (haddNano.py); in release since 13_0_18, 14_0_2, 14_1_0; it was not backported to 13_3_X
-git cms-addpkg PhysicsTools/NanoAOD
-git cms-cherry-pick-pr 43536 CMSSW_13_0_X
-
-#Pick more fixes in NanoAODTools (support for "S" branch types); in release since 14_0_0, 14_1_0; queued in 13_3_X (X>3)
+#Fix some memory ownership issues (unreleased)
 git cms-addpkg PhysicsTools/NanoAODTools
-git fetch https://github.com/namapane/cmssw.git NAT-dev:namapane_NAT-dev
-git cherry-pick 3e73ca4c2f8
-#Fix some memory ownership issues
 git fetch https://github.com/namapane/cmssw.git nanoAOD_memfix
 git cherry-pick ed6112b942d
 
+if ($CMSSW_VERSION =~ "CMSSW_13_3*") then
+ #Pick the fix from #43536 (haddNano.py); in release since 13_0_18, 14_0_2, 14_1_0; it was not backported to 13_3_X
+ git cms-addpkg PhysicsTools/NanoAOD
+ git cms-cherry-pick-pr 43536 CMSSW_13_0_X
+   
+ #Pick more fixes in NanoAODTools (support for "S" branch types); in release since 14_0_0, 14_1_0; queued in 13_3_X (X>3)
+ git fetch https://github.com/namapane/cmssw.git NAT-dev:namapane_NAT-dev
+ git cherry-pick 3e73ca4c2f8
+fi
+   
 #get nanoAODTools modules
 git clone https://github.com/cms-cat/nanoAOD-tools-modules.git PhysicsTools/NATModules
 


### PR DESCRIPTION
This update makes the checkout recipe ready to install on CMSSW_14_1_6, which is required to read egamma scale/smearing corrections for 2023 as they require a recent correctionlib version.

Note that the switch is not yet recommended as producing nanoAODs from mini in 14X also picks the Run3 HZZ electron ID, which is not present in nanoAOD v12. (Running on existing nanoAOD v12 samples is fine anyhow).

This PR also includes a port of #275 from the Run2UL_22 branch.