### PR TITLE
Make readSampleInfo py3 compatible

### DIFF
--- a/AnalysisStep/python/readSampleInfo.py
+++ b/AnalysisStep/python/readSampleInfo.py
@@ -1,7 +1,7 @@
 # Imported from:
 # https://raw.githubusercontent.com/bellan/VVXAnalysis/master/Producers/python/readSampleInfo.py
 #
-import sys, os, commands, math
+import sys, os, math
 
 
 def checkBool(val):
@@ -27,8 +27,6 @@ def readSamplesInfo(infoFilePath = 'samples_8TeV.csv', indexBy = 'identifier'):
   (csv) file.
   """
 
-  import string
-
   infoFile                  = open(infoFilePath, "r")
   database                  = {}
   defaults                  = {}
@@ -43,7 +41,7 @@ def readSamplesInfo(infoFilePath = 'samples_8TeV.csv', indexBy = 'identifier'):
     # Assign info to the entry indexed by the dataset identifier
     if header:            
       if len(data) != len(header):
-        raise ValueError, "Inconsistent number of columns in data '" + line + "', expected header = " + str(header)
+        raise ValueError("Inconsistent number of columns in data '" + line + "', expected header = " + str(header))
 
       info                  = {}
       for (key, value) in zip(header, data):
@@ -52,16 +50,16 @@ def readSamplesInfo(infoFilePath = 'samples_8TeV.csv', indexBy = 'identifier'):
           if len(value.strip()) == 0:
             value           = []
           else:
-            value           = map(string.strip, value.split(";"))
+            value           = [s.strip() for s in value.split(";")]
             for v in value:
-              bareelement = map(string.strip, v.split("="))
+              bareelement = [s.strip() for s in v.split("=")]
               if len(bareelement) == 2:
                 if isFloat(bareelement[1]):
                   try:
-							int(bareelement[1])==float(bareelement[1]) # int(float number) will return ValueError
-							dictionary[bareelement[0]] = int(bareelement[1]) # avoid turning integers to floats
+                    int(bareelement[1])==float(bareelement[1]) # int(float number) will return ValueError
+                    dictionary[bareelement[0]] = int(bareelement[1]) # avoid turning integers to floats
                   except ValueError:
-							dictionary[bareelement[0]] = float(bareelement[1])
+                    dictionary[bareelement[0]] = float(bareelement[1])
                 else:
                   dictionary[bareelement[0]] = checkBool(bareelement[1])
               else:
@@ -74,7 +72,7 @@ def readSamplesInfo(infoFilePath = 'samples_8TeV.csv', indexBy = 'identifier'):
 
       index                 = info[indexBy]
       if index in database:
-        raise ValueError, "Duplicate entries encountered for %d" % index
+        raise ValueError("Duplicate entries encountered for %d" % index)
       del info[indexBy]
       database[index]       = info
 
@@ -90,7 +88,7 @@ def readSamplesInfo(infoFilePath = 'samples_8TeV.csv', indexBy = 'identifier'):
 
 
   if len(database) == 0:
-    raise ValueError, "Invalid information file '" + infoFilePath + "', no entries found."
+    raise ValueError("Invalid information file '" + infoFilePath + "', no entries found.")
   return (database, defaults)
 
 
@@ -101,7 +99,7 @@ def readSampleInfo(sample, infoFilePath = 'samples_8TeV.csv', indexBy = 'identif
   if sample in db:
     return db[sample]
   else:
-    print "Unknown sample", sample
+    print("Unknown sample", sample)
     sys.exit(2)
 
 
@@ -112,7 +110,7 @@ def crossSection(sample, infoFilePath = 'samples_8TeV.csv', indexBy = 'identifie
 def readSampleDB(infoFilePath = 'samples_8TeV.csv', indexBy = 'identifier'):
   db,defaults = readSamplesInfo(infoFilePath, indexBy)
   for sample in db:
-    for key,val in db[sample].iteritems():
+    for key,val in db[sample].items():
       if key in defaults:
         if val == "":
           db[sample][key] = defaults[key]
@@ -141,7 +139,7 @@ def getSamplesBy(category, categoryvalue, infoFilePath = 'samples_8TeV.csv', ind
         samples.append(sample)
     else:
       if not category in DB[sample]: 
-        print "ERROR unknown category!"
+        print("ERROR unknown category!")
         return samples
       if DB[sample][category] == categoryvalue:
         samples.append(sample)


### PR DESCRIPTION
This patch makes readSampleInfo.py compatible with both python2 and python3.
This is needed to smooth the transition from Run2UL (CMSSW_10_6_X -> python2-only ROOT bindings) code to Run3 (CMSSW_13_3_X -> python3-only ROOT bindings), as well as enabling more flexibility for our current Run2UL analysis jobs in the HTCondor queues.

The changes were tested with:
```
python2 -m py_compile readSampleInfo.py
python3 -m py_compile readSampleInfo.py
```
in the CAT el7 container [1], both before and after having done `cmsenv` in CMSSW_10_6_26. The python3 version was also tested in native el9 (lxplus9).

[1] `/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/cms-cat/cmssw-lxplus/cmssw-el7-lxplus:latest/`