### PR TITLE
Add tentative jet cleaner + Updates for mu ID optimization studies

### DIFF
--- a/AnalysisStep/scripts/haddData.py
+++ b/AnalysisStep/scripts/haddData.py
@@ -4,7 +4,7 @@
 #
 # Usage:
 # haddData.py [folder]
-# [folder] = location of  (default: "AAAAOK")
+# [folder] = location of  (default: current directory)
 # Merged data are placed in a folder Data[year]/
 # in the CURRENT directory (not uder [folder]!)
 
@@ -17,7 +17,7 @@ import glob
 if len(sys.argv) > 1 :
     jobpath = str(sys.argv[1])
 else: 
-    jobpath = "AAAOK"
+    jobpath = "."
 
 # Check if the specified file is a nanoAOD file.
 def checkNano(file):
@@ -44,7 +44,7 @@ if len(chunks) :
     os.system('cd '+jobpath+'; mkdir -p Chunks; mv *_Chunk* Chunks')
 
 
-dataYears = ["2016","2017","2018","2022","2023"]
+dataYears = ["2016","2017","2018","2022","2023", "2024", "2025"]
 
 mergedYears = []
 isNano = False
@@ -66,7 +66,7 @@ for year in dataYears :
         print ("hadding files:", haddCmd)
         os.system(haddCmd)
 
-if len(mergedYears) :
+if len(mergedYears)>1 :
     # ... still have merge different years into a single file 
     dest = "AllData"
     os.system('mkdir -p '+dest)    

--- a/NanoAnalysis/python/ZZFiller.py
+++ b/NanoAnalysis/python/ZZFiller.py
@@ -69,26 +69,26 @@ class ZZFiller(Module):
 
         self.candsToStore = StoreOption.BestCandOnly # Only store the best candidate for the SR
 #        self.candsToStore = StoreOption.AllWithRelaxedMuId # Use this for ID optimization studies
-
-        # Pre-selection of leptons used to reduce combinatorial when building Z and LL candidates.
-        # Normally it is the full ID + iso if only the SR is considered, or the relaxed ID if CRs are also filled,
-        # but can be relaxed further to also build loose candidates for ID studies (see below).
-        # Note that the actual lepton selection cuts for SR and CR are applied later; this preselection only affects what
-        # leptons are considered in making the combinatorial (ie processing speed)
-        if self.addSIPCR or self.addOSCR or self.addSSCR :
-            self.leptonPresel = (lambda l : l.ZZRelaxedIdNoSIP) # minimal selection good for all CRs: no SIP, no ID, no iso
-        else : # SR only
-            self.leptonPresel = (lambda l : l.ZZFullSel)
-
         self.muonIDs=[]
         self.muonIDVars=[]
+
+        # Pre-selection of leptons used to reduce combinatorial when building Z and LL candidates.
+        # Note that the actual lepton selection cuts for SR and CR are applied later; this preselection only affects what
+        # leptons are considered in making the combinatorial (ie processing speed)
         
-        # Use relaxed muon preselection for muon ID studies: fully relax muon ID. Electron ID is unchanged.
-        if self.candsToStore == StoreOption.AllWithRelaxedMuId :
-            if self.addSIPCR or self.addOSCR or self.addSSCR :
-                self.leptonPresel = (lambda l : (abs(l.pdgId)==13 and l.pt>5 and abs(l.eta) < 2.4) or (abs(l.pdgId)==11 and l.ZZRelaxedIdNoSIP))
-            else : 
-                self.leptonPresel = (lambda l : (abs(l.pdgId)==13 and l.pt>5 and abs(l.eta) < 2.4) or (abs(l.pdgId)==11 and l.ZZFullSel))
+        if self.candsToStore != StoreOption.AllWithRelaxedMuId :
+            # Normal case: is the full ID + iso if only the SR is considered, or the relaxed ID if CRs are also filled.
+            if self.addSIPCR or self.addOSCR or self.addSSCR or self.addZLCR:
+                self.leptonPresel = (lambda l : l.ZZRelaxedIdNoSIP) # minimal selection good for all CRs: no SIP, no ID, no iso
+            else : # SR only
+                self.leptonPresel = (lambda l : l.ZZFullSel)
+        else :
+            # Use relaxed muon preselection for muon ID studies: fully relax muon ID.
+            # Electron ID is unchanged; FullSel electrons are preselected in this case, so the effect of cut variations can be studied for muons only.
+            # for this reason, CRs cannot be properly built.
+            if self.addSIPCR or self.addOSCR or self.addSSCR or self.addZLCR:
+                raise Exception("WARNING: CRs are not supported when StoreOption = AllWithRelaxedMuId")
+            self.leptonPresel = (lambda l : (abs(l.pdgId)==13 and l.pt>5 and abs(l.eta) < 2.4) or (abs(l.pdgId)==11 and l.ZZFullSel))
             
             # Add flags for muon ID studies. Each Flag will be set to true for a candidate if all of its muons pass the specified ID.
             self.muonIDs=[dict(name="ZZFullSel", sel=lambda l : l.ZZFullId and l.passIso), # Standard ZZ selection; this is used for setting default bestCandIdx
@@ -108,14 +108,16 @@ class ZZFiller(Module):
 
             # Add variable to store the worst value of a given quantity among the 4 leptons of a candidate, for optimization studies.
             # Worst is intended as lowest value (as for an MVA), unless the variable's name starts with "max".
-            self.muonIDVars=[dict(name="maxsip3d", sel=lambda l : l.sip3d if (abs(l.dxy)<0.5 and abs(l.dz) < 1) else 999.), # dxy, dz cuts included with SIP
+            self.muonIDVars=[dict(name="maxdxy", sel=lambda l : l.dxy),
+                             dict(name="maxdz", sel=lambda l : l.dz),
+                             dict(name="maxsip3d", sel=lambda l : l.sip3d),
                              dict(name="maxpfRelIso03FsrCorr", sel=lambda l : l.pfRelIso03FsrCorr), # FSR-corrected iso, DR=0.3
                              dict(name="maxpfRelIso03_all", sel=lambda l : l.pfRelIso03_all),
                              dict(name="maxpfRelIso04_all", sel=lambda l : l.pfRelIso04_all),
                              dict(name="maxminiPFRelIso_all", sel=lambda l : l.miniPFRelIso_all), # miniIso
-                             dict(name="mvaLowPt", sel=lambda l : l.mvaLowPt if (l.looseId and l.sip3d<4. and l.dxy<0.5 and l.dz < 1) else -2.), # additional presel is required, cf: https://github.com/cms-sw/cmssw/blob/90f498af750cf4271c0a988fef352b0698012a40/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc#L762-L764
-#                             dict(name="promptMVA", sel=lambda l : l.promptMVA if (l.looseId and l.sip3d<4. and l.dxy<0.5 and l.dz < 1) else -2.), # former mvaTTH. adding H4l preselection for consistencty with mvaLowPt; this is looser than the original recommendation (https://twiki.cern.ch/twiki/bin/viewauth/CMS/LeptonMVA). Variable retrained in v14 (and renamed)
-                             dict(name="mvaMuID", sel=lambda l : l.mvaMuID if (l.looseId and l.sip3d<4. and l.dxy<0.5 and l.dz < 1) else -2.), # muon MVA from 22-001. FIXME: Was retrained in v14; using H4l preselection for consistency, see above
+                             dict(name="mvaLowPt", sel=lambda l : l.mvaLowPt), # additional presel (l.looseId and l.sip3d<4. and l.dxy<0.5 and l.dz < 1) is required, cf: https://github.com/cms-sw/cmssw/blob/90f498af750cf4271c0a988fef352b0698012a40/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc#L762-L764
+#                             dict(name="promptMVA", sel=lambda l : l.mvaTTH), # should add H4l preselection for consistencty with mvaLowPt; this is looser than the original recommendation (https://twiki.cern.ch/twiki/bin/viewauth/CMS/LeptonMVA). Was retrained and renamed "promptMVA" in v14
+#                             dict(name="mvaMuID", sel=lambda l : l.mvaMuID), # muon MVA from 22-001. Note: Was retrained in v14; using H4l preselection for consistency, see above
                              ]
         if self.runMELA :
             sqrts=13.;
@@ -338,7 +340,7 @@ class ZZFiller(Module):
                 # Check that only one candidate is selected in each event for the 2 CRs of the OS method?
                 # Actually not needed, at the overlap is accounted for in the method
 #                if best2P2FCRIdx >= 0 and best3P1FCRIdx >= 0 :
-#                    print ('WARNING: event {}:{}:{} has CR candidates in both 2P2F and 3P1F regions'.format(event.run,event.luminosityBlock,event.event))   #FIXME choose the best among the two
+#                    print ('WARNING: event {}:{}:{} has CR candidates in both 2P2F and 3P1F regions'.format(event.run,event.luminosityBlock,event.event))
 
                 # Store only ZLL candidates that belong to at least 1 CR
                 for iZLL, ZLL in enumerate(ZLLsTemp) :
@@ -610,7 +612,9 @@ class ZZFiller(Module):
     ### Comparators to select the best candidate in the event. Return -1 if a is better than b, +1 otherwise
     # Choose by abs(MZ1-MZ), or sum(PT) if same Z1
     def bestCandByZ1Z2(self,a,b): 
-        if abs(a.Z1.M-b.Z1.M) < 1e-4 : # same Z1: choose the candidate with highest-pT Z2 leptons
+        if abs(a.Z1.M-b.Z1.M) < 1e-4 : # same Z1: choose the candidate with highest-pT Z2 leptons.
+            #FIXME replace the line above by a check by indices: 
+            #if a.Z1.l1Idx = b.Z1.l1Idx and a.Z1.l2Idx = b.Z1.l2Idx : #Note that leptons are ordered (1=+, 2=-), there is no need to check the alternative pairing:
             if a.Z2.sumpt() > b.Z2.sumpt() :
                 return -1
             else :
@@ -623,7 +627,10 @@ class ZZFiller(Module):
 
     # Choose by DbkgKin
     def bestCandByDbkgKin(self,a,b): 
-        if abs((a.p4).M() - (b.p4).M())<1e-4 and a.finalState()==b.finalState() and (a.finalState() == 28561 or a.finalState()==14641) : # Equivalent: same masss (tolerance 100 keV) and same FS -> same leptons and FSR
+        if abs((a.p4).M() - (b.p4).M())<1e-4 and a.finalState()==b.finalState() and (a.finalState() == 28561 or a.finalState()==14641) : # Equivalent: same masss (tolerance 100 keV) and same FS -> different permutation of the same leptons. Note that this can only happen in SR, not in CRs where the Z1 is always the best Z in the event.
+            # FIXME Replace the line above with a check by indices. 
+            # if set([a.Z1.l1Idx, a.Z1.l2Idx, a.Z2.l1Idx, a.Z2.l2Idx]) == \
+            #    set([b.Z1.l1Idx, b.Z1.l2Idx, b.Z2.l1Idx, b.Z2.l2Idx])) :
             return self.bestCandByZ1Z2(a,b)
         if a.KD > b.KD : return -1 # choose by best dbkgkin
         else: return 1
@@ -703,23 +710,23 @@ class ZZFiller(Module):
             p_QQB_BKG_MCFM = 1. # FIXME: fix for error with message: "TUtil::CheckPartonMomFraction: At least one of the parton momentum fractions is greater than 1."
         ZZ = self.ZZCand(Z1, Z2, p_GG_SIG_ghg2_1_ghz1_1_JHUGen, p_QQB_BKG_MCFM)
 
-        # Set flags for IDs passed by all leptons of candidate (muon only for the time being), which are 
-        # used for studies on ID tuning
+        # Set flags for IDs passed by all muons of candidate, and worst values of selection variables for the candidate's muons, for studies on muon ID optimization.
+        # For electrons, we rely on the fact that they are preselected as passing ZZFullSel (leptonPresel) when option AllWithRelaxedMuId is set.
         if fillIDVars:
             passId = [True]*len(self.muonIDs)
             for iID, ID in enumerate(self.muonIDs) :
                 for ilep in range(4):
-                    if abs(zzleps[ilep].pdgId)==13 and not ID["sel"](zzleps[ilep]) :
+                    if abs(zzleps[ilep].pdgId)==13 and not ID["sel"](zzleps[ilep]) : # electrons are already preselected, see above
                         passId[iID] = False
                         continue
             ZZ.passId = passId
 
-            # Set worst value of specified selection variables (muon only, for the time being)
+            # Set worst value of selection variable among all candidate's muons
             worstVar = [99.]*len(self.muonIDVars)
             for iVar, var in enumerate(self.muonIDVars):
                 if var["name"].startswith("max") : worstVar[iVar] = -1.
                 for iilep in range(4) :
-                    if abs(zzleps[iilep].pdgId)==11 : continue
+                    if abs(zzleps[iilep].pdgId)==11 : continue # electrons are already preselected, see above
                     else :
                         if var["name"].startswith("max") :
                             worstVar[iVar] = max(worstVar[iVar], var["sel"](zzleps[iilep]))                                    

--- a/NanoAnalysis/python/getEleBDTCut.py
+++ b/NanoAnalysis/python/getEleBDTCut.py
@@ -62,6 +62,6 @@ def getEleBDTCut(era, dataTag, nanoVersion, useUncorrPt=False) :
             return eleBDTCut_RunIII_ULTraining_def
 
     # Fallback: combination not supported
-    raise ValueError('getEleBDTCut: era '+ str(era)+', dataTag ' + dataTag + ', nanoVersion ' + nanoVersion + ' not supported')
+    raise ValueError('getEleBDTCut: era '+ str(era)+', dataTag ' + dataTag + ', nanoVersion ' + str(nanoVersion) + ' not supported')
 
 

--- a/NanoAnalysis/python/jetFiller.py
+++ b/NanoAnalysis/python/jetFiller.py
@@ -1,8 +1,10 @@
 ### 
-# -Jet-Lepton cross-cleaning. Should be called after JES/JEC modules.
+# Jet-Lepton cross-cleaning. Should be called after JES/JEC modules.
+# Cleaning is based on the fraction of jet pt that is carried by all leptons passing full sel
+# and their FSR photons in dR < 0.4. The jet is masked if the fraction is > 0.5.
 # TODO:
-# - to be implemented
 # - Add b-tagging info (?)
+# - take into account jet veto maps for nCleanedJetsPt30, JetLeadingIdx, etc?
 ###
 
 from __future__ import print_function
@@ -13,37 +15,66 @@ from PhysicsTools.HeppyCore.utils.deltar import deltaR
 class jetFiller(Module):
     def __init__(self):
         print("***jetFiller", flush=True)
+        self.dRMin = 0.4 # dR between lepton (or FSR) and jet to assume overlap
+        self.EFthreshold = 0.5 # threshold of leptons pt over jet pt to veto the jet
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
-        self.out.branch("Jet_ZZMask", "O", lenVar="nJet") # jet is vetoed by one of the candidate's leptons
-        self.out.branch("JetLeadingIdx", "S") # index of leading jet after cleaning
-        self.out.branch("JetSubleadingIdx", "S") #index of subleading jet after cleaning
-        self.out.branch("nCleanedJetsPt30", "B") #number of jets above 30 GeV
-        self.out.branch("nCleanedJetsPt30_jesUp", "B")
-        self.out.branch("nCleanedJetsPt30_jesDn", "B")
+        self.out.branch("Jet_ZZMask", "O", lenVar="nJet", title="jet is vetoed by selected leptons or FSR photons")
+        self.out.branch("Jet_ZZLepEF", "F", lenVar="nJet", title="Fraction of jet pt carried by the vetoing leptons or FSR photons", limitedPrecision=6),
+        self.out.branch("JetLeadingIdx", "S", title="index of leading jet after cleaning")
+        self.out.branch("JetSubleadingIdx", "S", title="index of subleading jet after cleaning")
+        self.out.branch("nCleanedJetsPt30", "B", title="number of cleaned jets above 30 GeV")
+        self.out.branch("nCleanedJetsPt30_jesUp", "B", title="number of cleaned jets, up JES variation")
+        self.out.branch("nCleanedJetsPt30_jesDn", "B", title="number of cleaned jets, down JES variation")
         # up/down variations...
 
     def analyze(self, event):
         jets = Collection(event, 'Jet')
         electrons = Collection(event, "Electron")
+        fsrs = Collection(event, "FsrPhoton")
         muons = Collection(event, "Muon")
         leps = list(muons)+ list(electrons)
         nlep=len(leps)
 
         ## Jet-lepton cleaning with best candidate's leptons and FSR..
         mask = [False]*event.nJet
+        jet_lepPtF = [0.]*event.nJet
         leadingJetIdx = -1
         subleadingJetIdx =-1
+        leadingJetPt = 0.
+        subleadingJetPt = 0.
         nCleanedJetsPt30=0
         nCleanedJetsPt30_jesDn=0
         nCleanedJetsPt30_jesUp=0
-        # TO BE IMPLEMENTED
+
         # According to the analysis recipe at https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsZZ4lRunIILegacy#Jets, "[jets] must be cleaned with a DeltaR>0.4 cut wrt all tight leptons in the event passing the SIP and isolation cut computed after FSR correction, as well as with all FSR collected photons attached to these leptons."
         # Note: the current implementation on miniAODs (https://github.com/CJLST/ZZAnalysis/blob/Run2UL_22_nano/AnalysisStep/plugins/JetsWithLeptonsRemover.cc) probably does something different than this. To be reviewed.
-
-
+        for ij, jet in enumerate(jets) :            
+            for lep in leps :
+                if not lep.ZZFullSel : continue
+                if deltaR(lep.eta, lep.phi, jet.eta, jet.phi) < self.dRMin :
+                    jet_lepPtF[ij] += lep.pt
+                if lep.fsrPhotonIdx >=0 :
+                    fsr = fsrs[lep.fsrPhotonIdx]
+                    if deltaR(fsr.eta, fsr.phi, jet.eta, jet.phi) < self.dRMin :
+                        jet_lepPtF[ij] += fsr.pt
+            jet_lepPtF[ij] /= jet.pt
+            if jet_lepPtF[ij] > self.EFthreshold :                
+                mask[ij] = True
+                if jet.pt > 30 : nCleanedJetsPt30 += 1
+                #FIXME: add jesUp, jesDn
+                
+                # Note: we cannot rely on the fact that the jet collection is sorted by pt since JES can change this.  
+                if jet.pt > leadingJetPt:
+                    leadingJetPt = jet.pt
+                    leadingJetIdx = ij 
+                elif jet.pt > subleadingJetPt :
+                    subleadingJetPt = jet.pt
+                    subleadingJetIdx = ij
+        
         self.out.fillBranch("Jet_ZZMask", mask)
+        self.out.fillBranch("Jet_ZZLepEF", jet_lepPtF)
         self.out.fillBranch("JetLeadingIdx", leadingJetIdx)
         self.out.fillBranch("JetSubleadingIdx", subleadingJetIdx)
         self.out.fillBranch("nCleanedJetsPt30", nCleanedJetsPt30)

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -191,7 +191,7 @@ if IsMC:
 
     post_sequence.append(mcTruthAnalyzer(dump=False)) # Gen final state etc.
 
-    if ADD_ALLEVENTS: # Add modules that produce the variables to be stored for all events at the beginni
+    if ADD_ALLEVENTS: # Add modules that produce the variables to be stored for all events at the beginning
         from ZZAnalysis.NanoAnalysis.genFiller import *
         from ZZAnalysis.NanoAnalysis.cloneBranches import *
         pre_sequence = [puWeight(LEPTON_SETUP, DATA_TAG),
@@ -303,6 +303,7 @@ p = PostProcessor(".", fileNames,
 print("Sequence to be run:")
 for mod in p.modules:
     print(" ", mod.__class__.__name__)
+print ("", flush=True)
 
 ### Run command should be issued by the calling scripy
 # p.run()

--- a/NanoAnalysis/python/tools.py
+++ b/NanoAnalysis/python/tools.py
@@ -33,6 +33,14 @@ def insertAfter(sequence, moduleName, module) :
             sequence.insert(im+1, module)
             return
 
+# Remove a module in a sequence
+def removeModule(sequence, moduleName) :
+    if type(moduleName)!=str :
+        raise ValueError("insertAfter: moduleName should be a string")
+    for im, m in enumerate(sequence) :
+        if type(m).__name__ == moduleName :
+            del sequence[im]
+        
 # Get the four leptons of a ZZ or ZLL candidate
 def getLeptons(aCand, event) :
     idxs = [aCand.Z1l1Idx, aCand.Z1l2Idx, aCand.Z2l1Idx, aCand.Z2l2Idx]


### PR DESCRIPTION
Tentative implementation of jet cleaning. 
 Cleaning is based on the fraction of jet pt that is carried by all leptons passing full sel
and their FSR photons within dR < 0.4. 
The jet mask flag is set if the fraction is > 0.5.

Note: the module also sets nCleanedJetsPt30 JetLeadingIdx, but that does not take into account jet veto maps for the time being,