### PR TITLE
Add module to recompute Jet_jetId variable in NanoAOD v12 to Fix Bug

### DIFF
--- a/NanoAnalysis/python/jetIdUpdate.py
+++ b/NanoAnalysis/python/jetIdUpdate.py
@@ -1,0 +1,47 @@
+from __future__ import print_function
+from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
+
+class jetIdUpdate(Module):
+    def __init__(self):
+        print("***jetIdUpdate", flush=True)
+
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        self.out = wrappedOutputTree
+        self.out.branch("Jet_jetId_new", "I", lenVar="nJet", title="Corrected Jet ID based on manual recipe for NanoAODv12")
+
+    def analyze(self, event):
+        jets = Collection(event, 'Jet')
+        new_jetId = []
+
+        for ijet, jet in enumerate(jets):
+            # Initialize Jet ID flags
+            Jet_passJetIdTight = False
+            Jet_passJetIdTightLepVeto = False
+
+            # Jet-passJetIdTight based on eta conditions
+            if abs(jet.eta) <= 2.7:
+                Jet_passJetIdTight = bool(jet.jetId & (1 << 1))
+            elif 2.7 < abs(jet.eta) <= 3.0:
+                Jet_passJetIdTight = bool(jet.jetId & (1 << 1)) and (jet.neHEF < 0.99)
+            elif abs(jet.eta) > 3.0:
+                Jet_passJetIdTight = bool(jet.jetId & (1 << 1)) and (jet.neEmEF < 0.4)
+
+            # Jet-passJetIdTightLepVeto based on additional lepton veto conditions
+            if abs(jet.eta) <= 2.7:
+                Jet_passJetIdTightLepVeto = Jet_passJetIdTight and (jet.muEF < 0.8) and (jet.chEmEF < 0.8)
+            else:
+                Jet_passJetIdTightLepVeto = Jet_passJetIdTight
+
+            # Determine the new jet ID
+            if Jet_passJetIdTight and not Jet_passJetIdTightLepVeto:
+                new_jetId.append(2)
+            elif Jet_passJetIdTight and Jet_passJetIdTightLepVeto:
+                new_jetId.append(6)
+            else:
+                new_jetId.append(0)
+
+        # Fill the new jet ID branch
+        self.out.fillBranch("Jet_jetId_new", new_jetId)
+
+        return True

--- a/NanoAnalysis/python/jetIdUpdate.py
+++ b/NanoAnalysis/python/jetIdUpdate.py
@@ -9,9 +9,9 @@ class jetIdUpdate(Module):
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
         # Rename the original Jet_jetId branch
-        self.out.branch("Jet_jetIdOriginal", "I", lenVar="nJet", title="Original Jet ID from NanoAOD")
+        self.out.branch("Jet_jetIdOriginal", "b", lenVar="nJet", title="Original Jet ID from NanoAOD")
         # Define the new corrected Jet_jetId branch
-        self.out.branch("Jet_jetId", "I", lenVar="nJet", title="Corrected Jet ID based on manual recipe for NanoAODv12")
+        self.out.branch("Jet_jetId", "b", lenVar="nJet", title="Corrected Jet ID based on manual recipe for NanoAODv12")
 
     def analyze(self, event):
         jets = Collection(event, 'Jet')

--- a/NanoAnalysis/python/jetIdUpdate.py
+++ b/NanoAnalysis/python/jetIdUpdate.py
@@ -8,13 +8,19 @@ class jetIdUpdate(Module):
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
-        self.out.branch("Jet_jetId_new", "I", lenVar="nJet", title="Corrected Jet ID based on manual recipe for NanoAODv12")
+        # Rename the original Jet_jetId branch
+        self.out.branch("Jet_jetIdOriginal", "I", lenVar="nJet", title="Original Jet ID from NanoAOD")
+        # Define the new corrected Jet_jetId branch
+        self.out.branch("Jet_jetId", "I", lenVar="nJet", title="Corrected Jet ID based on manual recipe for NanoAODv12")
 
     def analyze(self, event):
         jets = Collection(event, 'Jet')
         new_jetId = []
+        original_jetId = []
 
         for ijet, jet in enumerate(jets):
+            original_jetId.append(jet.jetId)
+
             # Initialize Jet ID flags
             Jet_passJetIdTight = False
             Jet_passJetIdTightLepVeto = False
@@ -41,7 +47,8 @@ class jetIdUpdate(Module):
             else:
                 new_jetId.append(0)
 
-        # Fill the new jet ID branch
-        self.out.fillBranch("Jet_jetId_new", new_jetId)
+        # Fill the original and new jet ID branches
+        self.out.fillBranch("Jet_jetIdOriginal", original_jetId)
+        self.out.fillBranch("Jet_jetId", new_jetId)
 
         return True

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -14,7 +14,6 @@ from ZZAnalysis.NanoAnalysis.triggerAndSkim import * # Trigger requirements are 
 from ZZAnalysis.NanoAnalysis.lepFiller import *
 from ZZAnalysis.NanoAnalysis.jetFiller import *
 from ZZAnalysis.NanoAnalysis.ZZFiller import *
-from ZZAnalysis.NanoAnalysis.jetIdUpdate import *
 from ZZAnalysis.NanoAnalysis.ZZExtraFiller import *
 from ZZAnalysis.NanoAnalysis.weightFiller import weightFiller
 
@@ -184,6 +183,7 @@ if APPLYELECORR and LEPTON_SETUP >=2022 :
 
 # Update of JetId from manual recipe for NanoAOD v12
 if NANOVERSION == 12:
+    from ZZAnalysis.NanoAnalysis.jetIdUpdate import *
     insertBefore(reco_sequence, 'jetFiller', jetIdUpdate())
 
 # Add jet corrections for Run 3

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -14,6 +14,7 @@ from ZZAnalysis.NanoAnalysis.triggerAndSkim import * # Trigger requirements are 
 from ZZAnalysis.NanoAnalysis.lepFiller import *
 from ZZAnalysis.NanoAnalysis.jetFiller import *
 from ZZAnalysis.NanoAnalysis.ZZFiller import *
+from ZZAnalysis.NanoAnalysis.jetIdUpdate import *
 from ZZAnalysis.NanoAnalysis.ZZExtraFiller import *
 from ZZAnalysis.NanoAnalysis.weightFiller import weightFiller
 
@@ -162,6 +163,7 @@ reco_sequence = [lepFiller(cuts, LEPTON_SETUP), # FSR and FSR-corrected iso; fla
                           filter=FILTER_EVENTS,
                           candsToStore=CANDSTOSTORE,
                           debug=DEBUG), # Build ZZ candidates; choose best candidate; filter events with candidates
+                 jetIdUpdate(), # Update of JetId from manual recipe for NanoAOD v12
                  jetFiller(), # Jets cleaning with leptons
                  ZZExtraFiller(IsMC, LEPTON_SETUP, DATA_TAG, PROCESS_CR), # Additional variables to selected candidates
                  # MELAFiller(), # Compute the full set of discriminants for the best candidate

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -163,7 +163,6 @@ reco_sequence = [lepFiller(cuts, LEPTON_SETUP), # FSR and FSR-corrected iso; fla
                           filter=FILTER_EVENTS,
                           candsToStore=CANDSTOSTORE,
                           debug=DEBUG), # Build ZZ candidates; choose best candidate; filter events with candidates
-                 jetIdUpdate(), # Update of JetId from manual recipe for NanoAOD v12
                  jetFiller(), # Jets cleaning with leptons
                  ZZExtraFiller(IsMC, LEPTON_SETUP, DATA_TAG, PROCESS_CR), # Additional variables to selected candidates
                  # MELAFiller(), # Compute the full set of discriminants for the best candidate
@@ -182,6 +181,11 @@ if APPLYMUCORR :
 if APPLYELECORR and LEPTON_SETUP >=2022 :
     from ZZAnalysis.NanoAnalysis.modules.eleScaleResProducer import getEleScaleRes
     insertBefore(reco_sequence, 'lepFiller', getEleScaleRes(LEPTON_SETUP, DATA_TAG, IsMC, overwritePt=True))
+
+# Update of JetId from manual recipe for NanoAOD v12
+if NANOVERSION == 12:
+    insertBefore(reco_sequence, 'jetFiller', jetIdUpdate())
+
 # Add jet corrections for Run 3
 if APPLYJETCORR and LEPTON_SETUP >=2022 :
     from ZZAnalysis.NanoAnalysis.modules.jetJERC import getJetCorrected


### PR DESCRIPTION
**PR Description**
In this PR I'm adding a new module to recompute the Jet_jetId variabile which is bugged in NanoAOD v12, as described in https://cms-talk.web.cern.ch/t/bug-in-the-jetid-flag-in-nanov12-and-nanov13/108135.

This module creates a new branch `Jet_jetId_new` which contains the updated value:
* == 2: pass Tight but not TightLeptonVeto
* == 6: pass Tight and TightLeptonVeto
* == 0: otherwise

The recipe to compute the correct jetId value is provided by JME in https://twiki.cern.ch/twiki/bin/view/CMS/JetID13p6TeV?rev=21#nanoAOD_Flags, and it's different for NanoV12 ("manual recipe") and NanoV13/14 (correctionlib)

**Validation**
Plots of the old `Jet_jetId` (Blue) and the new `Jet_jetId_new` (Red) for the preEE 2022 DY sample 
![jetID_histo_DY_preEE22](https://github.com/user-attachments/assets/af3b6b7a-3eda-4aac-9b12-341173e7ee55)

**Notes**
* Adding this new variable necessitates updates to modules that currently reference the jet ID. Currently, the only module that appears to be using it is the JetVeto Map module in nanoAOD-tools-modules (https://github.com/cms-cat/nanoAOD-tools-modules/blob/master/python/modules/jetVetoMap.py#L45)
* An alternative approach could be to modify this PR so that it overwrites the original Jet_jetId variable, instead of creating a new one.
