### PR TITLE
Updates to batch scripts + minor fixes

### DIFF
--- a/AnalysisStep/python/eostools.py
+++ b/AnalysisStep/python/eostools.py
@@ -172,7 +172,8 @@ def datasetToSource( prefix, dataset, fileprefix=''):
     recursive=True #FIXME: this is needed for central production, but care is needed if other stuff is present in the EOS path
 
     data=listFiles(dataset, prefix, recursive)
-
+    if data == None:
+        raise ValueError(f'ERROR: No file found in {dataset}')
     rootre = re.compile('.*root')
     files = [fileprefix+f for f in data if rootre.match(f)]
 

--- a/AnalysisStep/python/hadd.py
+++ b/AnalysisStep/python/hadd.py
@@ -113,6 +113,12 @@ def haddChunks(idir, removeDestDir, cleanUp=False, destdir=None ):
     if len(chunks)==0:
         print('warning: no chunk found.')
         return
+    if cleanUp:
+        chunkDir = 'Chunks'
+        if os.path.isdir(chunkDir):
+            raise ValueError(f'ERROR: {chunkDir} already present, please move it away')
+            # shutil.rmtree(chunkDir)
+        os.mkdir(chunkDir)
     for i, (comp, cchunks) in enumerate(chunks.items(), start=1):
         odir = '/'.join( [destdir, comp] )
         print()
@@ -124,14 +130,8 @@ def haddChunks(idir, removeDestDir, cleanUp=False, destdir=None ):
             if os.path.isdir( odir ):
                 shutil.rmtree(odir)
         haddRec(odir, cchunks)
-    if cleanUp:
-        chunkDir = 'Chunks'
-        if os.path.isdir('Chunks'):
-            shutil.rmtree(chunkDir)
-        os.mkdir(chunkDir)
-        print(chunks)
-        for comp, chunks in chunks.items():
-            for chunk in chunks:
+        if cleanUp:
+            for chunk in cchunks:
                 shutil.move(chunk, chunkDir)
         
 if __name__ == '__main__':

--- a/AnalysisStep/scripts/batch_Condor.py
+++ b/AnalysisStep/scripts/batch_Condor.py
@@ -207,7 +207,7 @@ executable              = $(directory)/batchScript.sh
 arguments               = {mainDir}/$(directory) $(ClusterId)$(ProcId)
 output                  = log/$(ClusterId).$(ProcId).out
 error                   = log/$(ClusterId).$(ProcId).err
-log                     = log/$(ClusterId).log
+log                     = log/$(ClusterId).$(ProcId).log
 Initialdir              = $(directory)
 request_memory          = '''+str(batchManager.jobmem)+'''
 #Possible values: longlunch, workday, tomorrow, etc.; cf. https://batchdocs.web.cern.ch/local/submit.html
@@ -399,7 +399,7 @@ class MyBatchManager:
                    self.max_materialize = 0
                else :
                    self.jobmem = '3000M'
-                   self.max_materialize = 50
+                   self.max_materialize = 150
 
        if self.jobflavour == None:
            if batchManager.options_.jobflavour != None:

--- a/AnalysisStep/scripts/checkProd.csh
+++ b/AnalysisStep/scripts/checkProd.csh
@@ -1,12 +1,17 @@
 #!/bin/tcsh
-# Search for missing root files
-# parameter to be specified: mf = move failed jobs
-#                            lf = link failed jobs (then you can run cleanup.csh; resubmit_Condor.csh in AAAFAIL)
-#                            quiet = do not list jobs that are still running
-
-#set echo
+# #set echo
 
 set opt=$1
+
+if ( $opt == "help" ) then
+    echo "Scan production chunks and archive completed ones."
+    echo "Options:"
+    echo " quiet = do not list jobs that are still running"
+    echo " dry = only print, do not move chunks"
+    echo " mf = move failed jobs to AAAFAIL"
+    echo " lf = link failed jobs (then you can run cleanup.csh; resubmit_Condor.csh in AAAFAIL)"
+    exit
+endif
 
 if ( $#argv >= 2 ) then
   set gooddir=$2
@@ -75,8 +80,10 @@ foreach chunk ( *Chunk* )
 
  # Archive succesful jobs, or report failure
  if ( $fail == "false" ) then
-  mkdir -p $gooddir
-  mv $chunk $gooddir/
+  if ( $opt != "dry" ) then 
+    mkdir -p $gooddir
+    mv $chunk $gooddir/
+  endif
  else
   set description=""
    if ( $exitStatus == 0 ) then

--- a/NanoAnalysis/python/ZZFiller.py
+++ b/NanoAnalysis/python/ZZFiller.py
@@ -577,9 +577,9 @@ class ZZFiller(Module):
     ### Comparators to select the best candidate in the event. Return -1 if a is better than b, +1 otherwise
     # Choose by abs(MZ1-MZ), or sum(PT) if same Z1
     def bestCandByZ1Z2(self,a,b): 
-        if abs(a.Z1.M-b.Z1.M) < 1e-4 : # same Z1: choose the candidate with highest-pT Z2 leptons.
-            #FIXME replace the line above by a check by indices: 
-            #if a.Z1.l1Idx = b.Z1.l1Idx and a.Z1.l2Idx = b.Z1.l2Idx : #Note that leptons are ordered (1=+, 2=-), there is no need to check the alternative pairing:
+        if a.Z1.l1Idx == b.Z1.l1Idx and a.Z1.l2Idx == b.Z1.l2Idx :
+            # Same Z1, choose by sum of Z2 pTs.
+            # Note that leptons are ordered (1=+, 2=-), there is no need to check the alternative pairing
             if a.Z2.sumpt() > b.Z2.sumpt() :
                 return -1
             else :
@@ -592,10 +592,10 @@ class ZZFiller(Module):
 
     # Choose by DbkgKin
     def bestCandByDbkgKin(self,a,b): 
-        if abs((a.p4).M() - (b.p4).M())<1e-4 and a.finalState()==b.finalState() and (a.finalState() == 28561 or a.finalState()==14641) : # Equivalent: same masss (tolerance 100 keV) and same FS -> different permutation of the same leptons. Note that this can only happen in SR, not in CRs where the Z1 is always the best Z in the event.
-            # FIXME Replace the line above with a check by indices. 
-            # if set([a.Z1.l1Idx, a.Z1.l2Idx, a.Z2.l1Idx, a.Z2.l2Idx]) == \
-            #    set([b.Z1.l1Idx, b.Z1.l2Idx, b.Z2.l1Idx, b.Z2.l2Idx])) :
+        if set([a.Z1.l1Idx, a.Z1.l2Idx, a.Z2.l1Idx, a.Z2.l2Idx]) == \
+           set([b.Z1.l1Idx, b.Z1.l2Idx, b.Z2.l1Idx, b.Z2.l2Idx]) :
+            # Equivalent: same masss (tolerance 100 keV) and same FS -> different permutation of the same leptons.
+            # Note that this can only happen in SR, not in CRs where the Z1 is always the best Z in the event.
             return self.bestCandByZ1Z2(a,b)
         if a.KD > b.KD : return -1 # choose by best dbkgkin
         else: return 1


### PR DESCRIPTION
- Tweaks for `max_materialize` to avoid log files for all jobs being written in the same file
- introduce support for submitting custom jobs (e.g. plotting on top of ZZ nanoAODs)  
   - Take into account the -i option in nanoAOD jobs
   - allow to set up IsMC as an explicit variable in the csv (in case it cannot be determined automatically from the dataset)
   - allow to specify JOBTYPE=nanoAOD in the csv variables, in case the job type cannot be determined automatically from the input file names
- Some improvements:
   - `haddChunks -c ` now archives chunks right after each dataset is merged, so if there is a failure it is not necessary to restart from scratch
   - add `checkProd.csh dry` option (just print out, do not move anything)
   - in ZZFiller, Best candidate selection now relies on the lepton indices rather than guessing identical leptons from matching invariant masses