### PR TITLE
Add jetId module for 2024

### DIFF
--- a/NanoAnalysis/python/jetIdUpdate.py
+++ b/NanoAnalysis/python/jetIdUpdate.py
@@ -1,6 +1,11 @@
-from __future__ import print_function
+"""
+This module recomputes the JetId as recommended for nanoAODv12 based on the example:
+https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID13p6TeV#nanoAOD_Flags
+For nanoAODv13 and later, the correctionlib-based module should be used instead (see python/modules/jetIdProducer.py)
+"""
 from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
+from array import array
 
 class jetIdUpdate(Module):
     def __init__(self):
@@ -8,56 +13,51 @@ class jetIdUpdate(Module):
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
-        # Rename the original Jet_jetId branch
-        self.out.branch("Jet_jetIdOriginal", "b", lenVar="nJet", title="Original Jet ID from NanoAOD")
-        # Define the new corrected Jet_jetId branch
+        self.has_jetId=hasattr(inputTree,'Jet_jetId')
+        # Define the new corrected Jet_jetId branch. "b" = UChar_t in ROOT
         self.out.branch("Jet_jetId", "b", lenVar="nJet", title="Corrected Jet ID based on manual recipe for NanoAODv12")
-        self.has_jetId=hasattr(inputTree,'Jet_jetId') #FIXME hack while we implement the correctionlib module
+        if self.has_jetId:
+            # Rename the original Jet_jetId branch
+            self.out.branch("Jet_jetIdOriginal", "b", lenVar="nJet", title="Original Jet ID from NanoAOD")
 
     def analyze(self, event):
         jets = Collection(event, 'Jet')
-        new_jetId = []
-        original_jetId = []
+        new_jetId = array('B', event.nJet*[0]) # Note: UChar_t is uppercase 'B' in python array
+        original_jetId = array('B', event.nJet*[0])
 
         for ijet, jet in enumerate(jets):
             if self.has_jetId :
-                original_jetId.append(jet.jetId)
-            else :
-                original_jetId.append(0)
+                original_jetId[ijet] = jet.jetId
 
             # Initialize Jet ID flags
             Jet_passJetIdTight = False
             Jet_passJetIdTightLepVeto = False
 
-            if not self.has_jetId:
-                pass # Will be replaced by a dedicated NATModule
+            # Jet-passJetIdTight based on eta conditions
+            if abs(jet.eta) <= 2.7:
+                Jet_passJetIdTight = bool(jet.jetId & (1 << 1))
+            elif 2.7 < abs(jet.eta) <= 3.0:
+                Jet_passJetIdTight = bool(jet.jetId & (1 << 1)) and (jet.neHEF < 0.99)
+            elif abs(jet.eta) > 3.0:
+                Jet_passJetIdTight = bool(jet.jetId & (1 << 1)) and (jet.neEmEF < 0.4)
 
+            # Jet-passJetIdTightLepVeto based on additional lepton veto conditions
+            if abs(jet.eta) <= 2.7:
+                Jet_passJetIdTightLepVeto = Jet_passJetIdTight and (jet.muEF < 0.8) and (jet.chEmEF < 0.8)
             else:
-
-                # Jet-passJetIdTight based on eta conditions
-                if abs(jet.eta) <= 2.7:
-                    Jet_passJetIdTight = bool(jet.jetId & (1 << 1))
-                elif 2.7 < abs(jet.eta) <= 3.0:
-                    Jet_passJetIdTight = bool(jet.jetId & (1 << 1)) and (jet.neHEF < 0.99)
-                elif abs(jet.eta) > 3.0:
-                    Jet_passJetIdTight = bool(jet.jetId & (1 << 1)) and (jet.neEmEF < 0.4)
-
-                # Jet-passJetIdTightLepVeto based on additional lepton veto conditions
-                if abs(jet.eta) <= 2.7:
-                    Jet_passJetIdTightLepVeto = Jet_passJetIdTight and (jet.muEF < 0.8) and (jet.chEmEF < 0.8)
-                else:
-                    Jet_passJetIdTightLepVeto = Jet_passJetIdTight
+                Jet_passJetIdTightLepVeto = Jet_passJetIdTight
 
             # Determine the new jet ID
             if Jet_passJetIdTight and not Jet_passJetIdTightLepVeto:
-                new_jetId.append(2)
+                new_jetId[ijet] = 2
             elif Jet_passJetIdTight and Jet_passJetIdTightLepVeto:
-                new_jetId.append(6)
+                new_jetId[ijet] = 6
             else:
-                new_jetId.append(0)
+                new_jetId[ijet] = 0
 
         # Fill the original and new jet ID branches
-        self.out.fillBranch("Jet_jetIdOriginal", original_jetId)
         self.out.fillBranch("Jet_jetId", new_jetId)
+        if self.has_jetId :
+            self.out.fillBranch("Jet_jetIdOriginal", original_jetId)
 
         return True

--- a/NanoAnalysis/python/modules/jetIdProducer.py
+++ b/NanoAnalysis/python/modules/jetIdProducer.py
@@ -1,0 +1,28 @@
+"""
+Instantiate jetId correctionlib module (for nanoAODv13 onwards, cf. https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/blob/master/examples/jetidExample.py)
+"""
+
+def getJetIdProducer(era, tag) :
+    from PhysicsTools.NATModules.modules.jetId import jetId
+    if era not in [2022,2023,2024]:
+        raise ValueError("getJetIdProducer: get: Era", era, "not supported")
+
+    if era == 2022:
+        if "pre_EE" in tag:
+            folderKey = "2022_Summer22"
+        else:
+            folderKey = "2022_Summer22EE"
+    
+    elif era == 2023:
+        if "pre_BPix" in tag:
+            folderKey = "2023_Summer23"
+        else:
+            folderKey = "2023_Summer23BPix"
+
+    elif era == 2024:
+       folderKey = "2024_Winter24"
+
+    json = f"/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/{folderKey}/jetid.json.gz"
+    print("***jetId: era:", era, "tag:", tag, "json:", json)
+       
+    return jetId(json)

--- a/NanoAnalysis/python/modules/jetJERC.py
+++ b/NanoAnalysis/python/modules/jetJERC.py
@@ -1,5 +1,3 @@
-import os
-
 def getJetCorrected(era, tag, is_mc, overwritePt=True) :
     from PhysicsTools.NATModules.modules.jetCorr import jetJERC
 

--- a/NanoAnalysis/python/modules/jetVMAP.py
+++ b/NanoAnalysis/python/modules/jetVMAP.py
@@ -1,5 +1,3 @@
-import os
-
 def getJetVetoMap(era, tag) :
     from PhysicsTools.NATModules.modules.jetVetoMap import jetVMAP
 
@@ -28,7 +26,6 @@ def getJetVetoMap(era, tag) :
 
     json_JVMAP = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/%s/jetvetomaps.json.gz" % (folderKey)
     veto_map_name= "jetvetomap"
-    print("folder key",folderKey)
-    print("***jetJVMAP: era:", era, "tag:", tag)
+    print("***jetJVMAP: era:", era, "tag:", tag, "corrName:", corrName, "json:", json_JVMAP)
 
     return jetVMAP(json_JVMAP, corrName, veto_map_name)

--- a/NanoAnalysis/python/modules/muonScaleResProducer_Rochester.py
+++ b/NanoAnalysis/python/modules/muonScaleResProducer_Rochester.py
@@ -1,10 +1,11 @@
-## This is derived from  PhysicsTools/NanoAODTools/python/postprocessing/modules/common/muonScaleResProducer.py
-## with modifications to:
-## - add sync mode
-## - replace lepton pT instead of adding a new variable (overwritePt=true)
-## - take RoccoR from the CJLST library instead than recompiling it
+"""
+This is derived from  PhysicsTools/NanoAODTools/python/postprocessing/modules/common/muonScaleResProducer.py
+with modifications to:
+- add sync mode
+- replace lepton pT instead of adding a new variable (overwritePt=true)
+- take RoccoR from the CJLST library instead than recompiling it
+"""
 
-from __future__ import print_function
 from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
 import os

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -195,10 +195,13 @@ if APPLYELECORR and LEPTON_SETUP >=2022 :
     from ZZAnalysis.NanoAnalysis.modules.eleScaleResProducer import getEleScaleRes
     insertBefore(reco_sequence, 'lepFiller', getEleScaleRes(LEPTON_SETUP, DATA_TAG, IsMC, overwritePt=True))
 
-# Update of JetId from manual recipe for NanoAOD v12
-if NANOVERSION >= 12:
+# Update of JetId: manual recipe for NanoAOD v12, using JSON for v13 onwards, cf https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID13p6TeV#nanoAOD_Flags
+if NANOVERSION == 12 :
     from ZZAnalysis.NanoAnalysis.jetIdUpdate import *
     insertBefore(reco_sequence, 'jetFiller', jetIdUpdate())
+elif NANOVERSION >=13 :
+    from ZZAnalysis.NanoAnalysis.modules.jetIdProducer import getJetIdProducer
+    insertBefore(reco_sequence, 'jetFiller', getJetIdProducer(LEPTON_SETUP, DATA_TAG))   
 
 # Add jet corrections for Run 3
 if APPLYJETCORR and LEPTON_SETUP >=2022 :

--- a/checkout_13X.csh
+++ b/checkout_13X.csh
@@ -82,7 +82,7 @@ fi
    
 #get nanoAODTools modules
 git clone https://github.com/cms-cat/nanoAOD-tools-modules.git PhysicsTools/NATModules
-(cd PhysicsTools/NATModules; git checkout -b from-906b58d 906b58d)
+(cd PhysicsTools/NATModules; git checkout -b from-37a092e 37a092e)
 
 
 #CommonLHETools requires the MELA env to be set for compilation


### PR DESCRIPTION
Following the [JME recommended recipe](https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID13p6TeV#nanoAOD_Flags), the manual `jetIdUpdate `module is now used for nanoAODv12, while the correctionlib-based module `jetId` from NATModules is used for v13 onwards.

Also add some minor cleanup/improvements.