### PR TITLE
Improvements in LHEAngProbFiller and RecoProbFiller

### DIFF
--- a/AnalysisStep/interface/Dataset.h
+++ b/AnalysisStep/interface/Dataset.h
@@ -1,0 +1,55 @@
+#ifndef DATASET_H
+#define DATASET_H
+
+#include <TChain.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <TSystemDirectory.h>
+#include <TList.h>
+#include <TCollection.h>
+
+#include <iostream>
+
+/**
+ * Dataset
+ * ----------
+ * Utility that mimics the interface of a TFile containing the Runs, Events and 
+ * (optionally) AllEvents trees, setting up TChains from all Chunks of a 
+ * given sample in the specified folder.
+ *
+ */
+class Dataset  {
+public:
+  /// Construct from path and sample name, eg: "ggH125".
+  /// Regex-style wildcards allowed, e.g.: ".*2022." = all 2022 data (all PDs, all eras)
+  /// delayOpen: speeds up initialization by skipping file opening and reading headers when they are added.
+  ///            This result in much faster initialization, but:
+  ///            - File errors (corrupted files, missing trees etc) will be found at the first access 
+  ///            - GetEntriesFast() will return TChain::kBigNumber, regardless of the real number of entries,
+  ///              until the chain is opened for the first time or GetEntries() is called.
+  /// verbosityLevel: 0 = only err; 2=debug
+  explicit Dataset(const TString& path,
+		   const TString& sampleName,
+		   bool delayOpen=false,
+		   int verbosityLevel=0);
+
+  ~Dataset();
+
+  /// (Re)scan and add all Chunk*/ZZ4lAnalysis.root under baseDir (non-recursive).
+  void AddChunks(const TString& baseDir, bool delayOpen);
+
+  /// Mimic TFile::Get: return the chain if user asks the tree by name
+  TObject* Get(const char* name);
+
+  /// Mimic direct tree access in interactive root and PyROOT
+  TChain* Runs;
+  TChain* Events;
+  TChain* AllEvents;
+  
+private:
+  TString sampleName_;
+  int verbosityLevel_;
+
+};
+
+#endif

--- a/AnalysisStep/src/Dataset.cc
+++ b/AnalysisStep/src/Dataset.cc
@@ -1,0 +1,91 @@
+#include "ZZAnalysis/AnalysisStep/interface/Dataset.h"
+#include <RtypesCore.h>
+#include <regex>
+#include <stdexcept>
+#include <TFile.h>
+
+using namespace std;
+
+Dataset::Dataset(const TString& path, const TString& sampleName, bool delayOpen, int verbosityLevel)
+  : Runs(nullptr),
+    Events(nullptr),
+    AllEvents(nullptr),
+    sampleName_(sampleName),
+    verbosityLevel_(verbosityLevel) {
+  AddChunks(path, delayOpen);
+}
+
+Dataset::~Dataset() {
+  delete Runs;
+  delete Events;
+  delete AllEvents;
+}
+
+void Dataset::AddChunks(const TString& path, bool delayOpen) {
+  TSystemDirectory basedir(path, path);
+  TList* subdirs = basedir.GetListOfFiles();
+  if (!subdirs) {
+    cerr << "[Dataset] Cannot list directory: " << path << endl;
+    return;
+  }
+
+  regex chunkRe(sampleName_+"_Chunk[0-9]+$");
+  
+  TIter next(subdirs);
+  int fileCount = 0;
+  while (TObject* o = next()) {
+    const char* name = o->GetName();
+
+    Long64_t mode = 0;
+    if (delayOpen) mode = TChain::kBigNumber;
+    
+    if (!name || name[0] == '.') continue; // skip . .. and hidden files
+    if (regex_match(name, chunkRe)) {
+      TString filePath = TString::Format("%s/%s/ZZ4lAnalysis.root",path.Data(), name);
+	
+      if (!gSystem->AccessPathName(filePath)) {
+	// Check which trees are contained in the first file
+	if (Events==nullptr) {
+	  auto f = TFile::Open(filePath);
+	  if (f->Get("Runs") != nullptr and f->Get("Runs") != nullptr) {
+	    Runs = new TChain("Runs");
+	    Events = new TChain("Events");
+	  } else {
+	    throw runtime_error("File "+filePath+" has no Runs/Events tree");
+	  }
+	  if (f->Get("AllEvents") != nullptr) { // optional tree
+	    AllEvents = new TChain("AllEvents");
+	  }
+	  f->Close();
+	}
+
+	// Note: -1 forces reading the tree's header to read the number of events; otherwise
+	int n1 = Runs->Add(filePath,mode);
+	int n2 = Events->Add(filePath,mode);
+	int n3 = -1;
+	if (AllEvents!=nullptr) n3 = AllEvents->Add(filePath, mode);
+	if (verbosityLevel_>=2) cout << "Adding " << filePath << endl;
+	if (n1==0 || n2==0 || n3 ==0) {
+	  throw runtime_error(TString("Tree ") +(n1==0?"Runs ":"")+(n2==0?"Events ":"")+(n3==0?"AllEvents ":"")+"not found in "+filePath);
+	}
+	fileCount++;
+      } else {
+	throw runtime_error("Missing file: "+filePath);
+      }
+    }
+  }
+
+  if (fileCount==0) {
+    throw runtime_error("No valid tree found in  "+path+ " for datset "+sampleName_);
+  } else {
+    cout << "Dataset " << sampleName_ << ": opened " << fileCount << " files" << endl;
+  }
+}
+
+
+TObject* Dataset::Get(const char* name) {
+  TString req(name);
+  if (req == "Events") return Events;
+  else if (req == "AllEvents") return AllEvents;
+  else return nullptr;
+}

--- a/AnalysisStep/src/classes.h
+++ b/AnalysisStep/src/classes.h
@@ -3,6 +3,7 @@
 #include <ZZAnalysis/AnalysisStep/interface/LeptonSFHelper.h>
 #include <ZZAnalysis/AnalysisStep/interface/kFactors.h>
 #include <ZZAnalysis/AnalysisStep/interface/WeightCalculatorFromHistogram.h>
+#include <ZZAnalysis/AnalysisStep/interface/Dataset.h>
 #include <vector>
 
 

--- a/AnalysisStep/src/classes_def.xml
+++ b/AnalysisStep/src/classes_def.xml
@@ -1,10 +1,11 @@
 <lcgdict>
   <class name="edm::Ptr<pat::PFParticle>"/>
   <class name="std::vector<edm::Ptr<pat::PFParticle> >"/>
-  <class name="pat::UserHolder<std::vector<edm::Ptr<pat::PFParticle> > >" />
+  <class name="pat::UserHolder<std::vector<edm::Ptr<pat::PFParticle> > >"/>
   <class name="LeptonSFHelper"/>
   <class name="KFactors"/>
-  <class name="Mela" />
-  <class name="TUtil" />
+  <class name="Mela"/>
+  <class name="TUtil"/>
   <class name="WeightCalculatorFromHistogram"/>
+  <class name="Dataset"/>
 </lcgdict>

--- a/NanoAnalysis/python/LHEAngProbFiller.py
+++ b/NanoAnalysis/python/LHEAngProbFiller.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import copy
 from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
 from PhysicsTools.HeppyCore.utils.deltar import deltaR
@@ -11,13 +12,58 @@ class LHEAngProbFiller(Module):
     MELA = Pointer to MELA passed from nanoZZ4lAnalysis.py 
     """
     
-    def __init__(self, MELA, NANOVERSION, settingsDict = None):
-        print("***LHEAngProbFiller", flush=True)
+    def __init__(self, MELA, NANOVERSION, MELASettings = None):
         self.MELA = MELA
-        self.MELAsettings = settingsDict
         self.NANOVERSION = NANOVERSION
-        print("THIS IS NANOVERSION: ", self.NANOVERSION)
+        self.sortedSettings = []
+
+        if MELASettings != None:
+            defaults = {
+                "Name": "Default_You_Should_Rename_This",
+                "Process": None, 
+                "MatrixElement": None, 
+                "Production":None, 
+                "Prod": None, 
+                "Dec": None, 
+                "Couplings": None, 
+                "isgen": None, 
+                "computeprop": None, 
+                "propscheme": "FixedWidth", 
+                "decaymode": "CandidateDecay_ZZ",
+                "separatewwzz":False,
+                "useconstant":False,
+                "match_mX":False,
+                "lepton_interference":"DefaultLeptonInterf",
+                "ispm4l": None,
+                "dividep": None
+            }
             
+            for prob in MELASettings:
+                if (not prob["isgen"]): continue # Only calculate LHE-level probabilities in this module.
+
+                ### Merge specific settings with defaults and check for unsupported values
+                fprob=copy.deepcopy(defaults)
+                for key, value in prob.items():
+                    if key in defaults:
+                        fprob[key] = value
+                    else:
+                        raise(ValueError(f"LHEAngProbFiller: unknown parameter {key} in {prob['Name']}"))
+
+                ### Sort the MELASettings dictionary so that all probabilities with divideP are last 
+                if (fprob["dividep"]==None):
+                    self.sortedSettings.insert(0,fprob)
+                else:
+                    self.sortedSettings.append(fprob)
+
+            ### Add index of probability to be used for dividep.
+            names = [d["Name"] for d in self.sortedSettings]
+            for prob in self.sortedSettings:
+                dp = prob["dividep"]
+                prob["dividep_idx"] = (-1 if dp == None else names.index(dp))
+
+            print(f"***LHEAngProbFiller: probs: {names}", flush=True)
+            
+        
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
         self.out.branch("LHEMela_qH", "F", title="The mass of the Higgs candidate as reconstructed by the 4-leptons at LHE-level.")
@@ -28,25 +74,16 @@ class LHEAngProbFiller(Module):
         self.out.branch("LHEMela_Phi", "F", limitedPrecision=16, title="In the Higgs' rest frame, phi is the angle between the planes formed by the decay products of the two Z bosons.")
         self.out.branch("LHEMela_costhetastar", "F", limitedPrecision=16, title="In the Higgs' rest frame, theta_star is the angle between the beamline and the momentum of one of the Higgs' decay products.")
         self.out.branch("LHEMela_Phi1", "F", limitedPrecision=16, title="In the Higgs' rest frame, phi_1 is the angle between the decay plane of Z1 and the beamline.")
-        if self.MELAsettings != None: 
-            ### Sort the MELASettings dictionary so that all probabilities with divideP are last
-            self.sortedSettings = []
-            self.denominator_name = ""
-            for i, prob in enumerate(self.MELAsettings):
-                if ("dividep" in prob) and (prob["isgen"] == True): 
-                    self.sortedSettings.append(prob)
-                    self.denominator_name = prob["dividep"]
-                else: 
-                    self.sortedSettings.insert(0,prob)
-                if prob["isgen"]:  
-                    self.out.branch(f"LHEMela_{prob['Name']}", "F", limitedPrecision=16, title="User-defined LHE-level probability")
-                    if prob.get("ispm4l", False): 
-                        self.out.branch("LHEMela_"+prob["Name"]+"_ScaleUp", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Scale uncertainties up")
-                        self.out.branch("LHEMela_"+prob["Name"]+"_ScaleDown", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Scale uncertainties down")
-                        self.out.branch("LHEMela_"+prob["Name"]+"_SystUp", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Systematic uncertainties up")
-                        self.out.branch("LHEMela_"+prob["Name"]+"_SystDown", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Systematic uncertainties down")
-                    if prob["computeprop"]: 
-                        self.out.branch("LHEMela_"+prob["Name"]+"_prop", "F", limitedPrecision=16, title="User-defined LHE-level probability with non-default propagator scheme")
+        if len(self.sortedSettings) !=0 :
+            for i, prob in enumerate(self.sortedSettings):
+                self.out.branch(f"LHEMela_{prob['Name']}", "F", limitedPrecision=16, title="User-defined LHE-level probability")
+                if prob.get("ispm4l", False): 
+                    self.out.branch("LHEMela_"+prob["Name"]+"_ScaleUp", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Scale uncertainties up")
+                    self.out.branch("LHEMela_"+prob["Name"]+"_ScaleDown", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Scale uncertainties down")
+                    self.out.branch("LHEMela_"+prob["Name"]+"_SystUp", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Systematic uncertainties up")
+                    self.out.branch("LHEMela_"+prob["Name"]+"_SystDown", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Systematic uncertainties down")
+                if prob["computeprop"]: 
+                    self.out.branch("LHEMela_"+prob["Name"]+"_prop", "F", limitedPrecision=16, title="User-defined LHE-level probability with non-default propagator scheme")
 
         
     def analyze(self, event):
@@ -63,8 +100,6 @@ class LHEAngProbFiller(Module):
             LHEDaughters = filter(lambda p: p.MELAStatus==2, LHEPart)
             LHEAssociated = filter(lambda p: p.MELAStatus==3, LHEPart)
 
-            
-
             status2 = filter(lambda p: p.status==2, LHEPart)
             for i, mp in enumerate(LHEMothers): 
                 temp_particle = Mela.SimpleParticle_t(mp.pdgId, mp.pt, mp.eta, mp.phi, mp.mass, True)
@@ -73,9 +108,6 @@ class LHEAngProbFiller(Module):
             for i, dp in enumerate(LHEDaughters): 
                 temp_particle = Mela.SimpleParticle_t(dp.pdgId, dp.pt, dp.eta, dp.phi, dp.mass, True)
                 daughters.add_particle(temp_particle)
-
-
-                
             
             for i, ap in enumerate(LHEAssociated): 
                 temp_particle = Mela.SimpleParticle_t(ap.pdgId, ap.pt, ap.eta, ap.phi, ap.mass, True)
@@ -109,12 +141,7 @@ class LHEAngProbFiller(Module):
                     continue
         else: 
             print("**genAngProbFiller: No version of NANOAOD specified!")
-        
-
-
-
-        # print("Dau len: ", len(daughters.toList()))
-
+            
         #Check if selected 4-leps match the higgs: 
         if abs(hMass - daughters.MTotal()) < 0.01 and len(daughters.toList()) == 4:
             # self.MELA.setInputEvent(daughters, associated, mothers, 1)
@@ -125,125 +152,91 @@ class LHEAngProbFiller(Module):
             self.out.fillBranch("LHEMela_Phi", Phi)
             self.out.fillBranch("LHEMela_Phi1", Phi1)
             self.out.fillBranch("LHEMela_costhetastar", costhetastar)
-            self.MELA.resetInputEvent()
         else: 
             if len(daughters.toList()) != 4: 
                 print(f"WARNING: LHEAngProbFiller: {len(daughters.toList())} LHE-leptons were selected for this event (4 expected)!")
             elif abs(hMass - daughters.MTotal()) < 0.01: 
                 print(f"WARNING: LHEAngProbFiller: The invariant mass of the four LHE-leptons, {daughters.MTotal()}, is too different from the mass of the LHE-Higgs {hMass}! Expected a difference of less than 0.01, obtained a difference of ", hMass - daughters.MTotal())
-            self.MELA.resetInputEvent()
 
-        if self.MELAsettings != None and len(daughters.toList()) == 4: 
-            for p, prob in enumerate(self.sortedSettings):
+        self.MELA.resetInputEvent()
+
+        if len(self.sortedSettings) != 0 and len(daughters.toList()) == 4:
+            vprob = [0.]*len(self.sortedSettings)
+            for iprob, prob in enumerate(self.sortedSettings):
 
                 ### Reset the event and the default probability settings per probability to be calculated. 
                 self.MELA.setInputEvent(daughters, associated, mothers, 1)
-                setupInputs = {
-                    "Name": "Default_You_Should_Rename_This",
-                    "Process": None, 
-                    "MatrixElement": None, 
-                    "Production":None, 
-                    "Prod": None, 
-                    "Dec": None, 
-                    "Couplings": None, 
-                    "isgen": None, 
-                    "computeprop": None, 
-                    "propscheme": "FixedWidth", 
-                    "decaymode": "CandidateDecay_ZZ",
-                    "separatewwzz":False,
-                    "useconstant":False,
-                    "match_mX":False,
-                    "lepton_interference":"DefaultLeptonInterf",
-                    "ispm4l": None,
-                    "dividep": None 
-                }
-                ### Only calculate LHE-level probabilities in this function. 
-                if prob["isgen"]:  
-                    ### Parse MELA settings for the desired probability and overwrite setup for all given parameters:
-                    for key, val in prob.items(): setupInputs[key] = prob[key]
 
-                    ### Define everything 
-                    MELA_Name = setupInputs["Name"]
-                    MELA_Process = check_enum(setupInputs["Process"], Mela.Process)
-                    MELA_MatrixElement = check_enum(setupInputs["MatrixElement"], Mela.MatrixElement)
-                    MELA_Production = check_enum(setupInputs["Production"], Mela.Production)
-                    MELA_prod = setupInputs["Prod"]
-                    MELA_dec = setupInputs["Dec"]
-                    MELA_computeprop = setupInputs["computeprop"]
-                    MELA_propscheme = check_enum(setupInputs["propscheme"], Mela.ResonancePropagatorScheme)
-                    MELA_separatewwzz = setupInputs["separatewwzz"]
-                    MELA_useconstant = setupInputs["useconstant"]
-                    MELA_matchMx = setupInputs["match_mX"]
-                    MELA_leptoninterference = check_enum(setupInputs["lepton_interference"], Mela.LeptonInterference)
-                    MELA_ispm4l = setupInputs["ispm4l"]
-                    MELA_divideP = setupInputs["dividep"]
+                ### Define everything 
+                MELA_Name = prob["Name"]
+                MELA_Process = check_enum(prob["Process"], Mela.Process)
+                MELA_MatrixElement = check_enum(prob["MatrixElement"], Mela.MatrixElement)
+                MELA_Production = check_enum(prob["Production"], Mela.Production)
+                MELA_prod = prob["Prod"]
+                MELA_dec = prob["Dec"]
+                MELA_computeprop = prob["computeprop"]
+                MELA_propscheme = check_enum(prob["propscheme"], Mela.ResonancePropagatorScheme)
+                MELA_separatewwzz = prob["separatewwzz"]
+                MELA_useconstant = prob["useconstant"]
+                MELA_matchMx = prob["match_mX"]
+                MELA_leptoninterference = check_enum(prob["lepton_interference"], Mela.LeptonInterference)
+                MELA_ispm4l = prob["ispm4l"]
+                MELA_divideP_idx = prob["dividep_idx"]
 
-                    ### Configure MELA for the event. 
-                    self.MELA.setProcess(MELA_Process, MELA_MatrixElement, MELA_Production)
-                    self.MELA.differentiate_HWW_HZZ = MELA_separatewwzz
-                    self.MELA.setMelaLeptonInterference(MELA_leptoninterference)
-
-                    
-
-                    if MELA_matchMx: 
-                        self.MELA.setMelaHiggsMassWidth(daughters.MTotal(), 0.00001, 0)
-                        self.MELA.setMelaHiggsMassWidth(daughters.MTotal(), 0.00001, 1)
-                    
-                    for coupl, coupl_val in setupInputs["Couplings"].items(): 
-                        setattr(self.MELA, coupl, coupl_val)
-
-
-
-                    
-                    if MELA_prod and MELA_dec: 
-                        probability = self.MELA.computeProdDecP(MELA_useconstant)
-                    elif MELA_prod: 
-                        probability = self.MELA.computeProdP(MELA_useconstant)
-                    elif MELA_dec:
-                        probability = self.MELA.computeP(MELA_useconstant)
-                    elif MELA_ispm4l: 
-                        probability = self.MELA.computePM4L(Mela.SuperMelaSyst.SMSyst_None)
-                        probability_ScaleUp = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ScaleUp)
-                        probability_ScaleDown = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ScaleDown)
-                        probability_SystUp = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResUp)
-                        probability_SystDown = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResDown)
-
-                        self.out.fillBranch("LHEMela_"+setupInputs["Name"]+"_ScaleUp", probability_ScaleUp)
-                        self.out.fillBranch("LHEMela_"+setupInputs["Name"]+"_ScaleDown", probability_ScaleDown)
-                        self.out.fillBranch("LHEMela_"+setupInputs["Name"]+"_SystUp", probability_SystUp)
-                        self.out.fillBranch("LHEMela_"+setupInputs["Name"]+"_SystDown", probability_SystDown)
-
-
-                    else:
-                        raise KeyError("Need to specify either production, decay, pm4l, or computeprop!")
-                    
-                    if MELA_computeprop and (MELA_prod or MELA_dec): 
-                        probabilityprop = self.MELA.getXPropagator(MELA_propscheme)
-                        self.out.fillBranch("LHEMela_"+setupInputs["Name"]+"_prop", probabilityprop)
-                    elif MELA_computeprop: 
-                        probability = self.MELA.getXPropagator(MELA_propscheme)
-                    
-
-                    # Save probability for DivideP purposes: 
-                    if MELA_Name == self.denominator_name:
-                        denominator = probability
-
-                    
-                    if MELA_divideP is not None:
-                        if denominator != 0: 
-                            probability /= denominator
-                        else: 
-                            print("**LHEAngProbFiller: Protecting against division by 0!")
-
-
-                
-                
-                
-                
+                ### Configure MELA for the event. 
+                self.MELA.setProcess(MELA_Process, MELA_MatrixElement, MELA_Production)
+                self.MELA.differentiate_HWW_HZZ = MELA_separatewwzz
+                self.MELA.setMelaLeptonInterference(MELA_leptoninterference)
                 
 
-                    self.out.fillBranch("LHEMela_"+prob["Name"], probability)
-                    self.MELA.resetInputEvent()
+                if MELA_matchMx: 
+                    self.MELA.setMelaHiggsMassWidth(daughters.MTotal(), 0.00001, 0)
+                    self.MELA.setMelaHiggsMassWidth(daughters.MTotal(), 0.00001, 1)
+                
+                for coupl, coupl_val in prob["Couplings"].items(): 
+                    setattr(self.MELA, coupl, coupl_val) # FIXME: This needs to be reset at the beginning of the loop?
+
+                
+                if MELA_prod and MELA_dec: 
+                    probability = self.MELA.computeProdDecP(MELA_useconstant)
+                elif MELA_prod: 
+                    probability = self.MELA.computeProdP(MELA_useconstant)
+                elif MELA_dec:
+                    probability = self.MELA.computeP(MELA_useconstant)
+                elif MELA_ispm4l: 
+                    probability = self.MELA.computePM4L(Mela.SuperMelaSyst.SMSyst_None)
+                    probability_ScaleUp = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ScaleUp)
+                    probability_ScaleDown = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ScaleDown)
+                    probability_SystUp = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResUp)
+                    probability_SystDown = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResDown)
+
+                    self.out.fillBranch("LHEMela_"+prob["Name"]+"_ScaleUp", probability_ScaleUp)
+                    self.out.fillBranch("LHEMela_"+prob["Name"]+"_ScaleDown", probability_ScaleDown)
+                    self.out.fillBranch("LHEMela_"+prob["Name"]+"_SystUp", probability_SystUp)
+                    self.out.fillBranch("LHEMela_"+prob["Name"]+"_SystDown", probability_SystDown)
+
+
+                else:
+                    raise KeyError("Need to specify either production, decay, pm4l, or computeprop!")
+                
+                if MELA_computeprop and (MELA_prod or MELA_dec): 
+                    probabilityprop = self.MELA.getXPropagator(MELA_propscheme)
+                    self.out.fillBranch("LHEMela_"+prob["Name"]+"_prop", probabilityprop)
+                elif MELA_computeprop: 
+                    probability = self.MELA.getXPropagator(MELA_propscheme)
+                
+                # Handle divideP 
+                vprob[iprob] = probability
+                if MELA_divideP_idx != -1:
+                    den = vprob[MELA_divideP_idx]
+                    if den != 0: 
+                        probability /= den
+                    else: 
+                        print("**LHEAngProbFiller: Protecting against division by 0!")
+                
+
+                self.out.fillBranch("LHEMela_"+prob["Name"], probability)
+                self.MELA.resetInputEvent()
         
        
         

--- a/NanoAnalysis/python/LHEAngProbFiller.py
+++ b/NanoAnalysis/python/LHEAngProbFiller.py
@@ -49,6 +49,9 @@ class LHEAngProbFiller(Module):
                     else:
                         raise(ValueError(f"LHEAngProbFiller: unknown parameter {key} in {prob['Name']}"))
 
+                # Add branch name so it does not need to be remade within loops
+                fprob["branchname"] = f"LHEMela_P_{prob['Name']}"
+
                 ### Sort the MELASettings dictionary so that all probabilities with divideP are last 
                 if (fprob["dividep"]==None):
                     self.sortedSettings.insert(0,fprob)
@@ -76,14 +79,14 @@ class LHEAngProbFiller(Module):
         self.out.branch("LHEMela_Phi1", "F", limitedPrecision=16, title="In the Higgs' rest frame, phi_1 is the angle between the decay plane of Z1 and the beamline.")
         if len(self.sortedSettings) !=0 :
             for i, prob in enumerate(self.sortedSettings):
-                self.out.branch(f"LHEMela_{prob['Name']}", "F", limitedPrecision=16, title="User-defined LHE-level probability")
+                self.out.branch(prob["branchname"], "F", limitedPrecision=16, title="User-defined LHE-level probability")
                 if prob.get("ispm4l", False): 
-                    self.out.branch("LHEMela_"+prob["Name"]+"_ScaleUp", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Scale uncertainties up")
-                    self.out.branch("LHEMela_"+prob["Name"]+"_ScaleDown", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Scale uncertainties down")
-                    self.out.branch("LHEMela_"+prob["Name"]+"_SystUp", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Systematic uncertainties up")
-                    self.out.branch("LHEMela_"+prob["Name"]+"_SystDown", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Systematic uncertainties down")
+                    self.out.branch(prob["branchname"]+"_ScaleUp", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Scale uncertainties up")
+                    self.out.branch(prob["branchname"]+"_ScaleDown", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Scale uncertainties down")
+                    self.out.branch(prob["branchname"]+"_SystUp", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Systematic uncertainties up")
+                    self.out.branch(prob["branchname"]+"_SystDown", "F", limitedPrecision=16, title="User-defined LHE-level m4l probability with Systematic uncertainties down")
                 if prob["computeprop"]: 
-                    self.out.branch("LHEMela_"+prob["Name"]+"_prop", "F", limitedPrecision=16, title="User-defined LHE-level probability with non-default propagator scheme")
+                    self.out.branch(prob["branchname"]+"_prop", "F", limitedPrecision=16, title="User-defined LHE-level probability with non-default propagator scheme")
 
         
     def analyze(self, event):
@@ -182,6 +185,7 @@ class LHEAngProbFiller(Module):
                 MELA_leptoninterference = check_enum(prob["lepton_interference"], Mela.LeptonInterference)
                 MELA_ispm4l = prob["ispm4l"]
                 MELA_divideP_idx = prob["dividep_idx"]
+                MELA_branchname = prob["branchname"]
 
                 ### Configure MELA for the event. 
                 self.MELA.setProcess(MELA_Process, MELA_MatrixElement, MELA_Production)
@@ -194,8 +198,7 @@ class LHEAngProbFiller(Module):
                     self.MELA.setMelaHiggsMassWidth(daughters.MTotal(), 0.00001, 1)
                 
                 for coupl, coupl_val in prob["Couplings"].items(): 
-                    setattr(self.MELA, coupl, coupl_val) # FIXME: This needs to be reset at the beginning of the loop?
-
+                    setattr(self.MELA, coupl, coupl_val)
                 
                 if MELA_prod and MELA_dec: 
                     probability = self.MELA.computeProdDecP(MELA_useconstant)
@@ -210,20 +213,19 @@ class LHEAngProbFiller(Module):
                     probability_SystUp = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResUp)
                     probability_SystDown = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResDown)
 
-                    self.out.fillBranch("LHEMela_"+prob["Name"]+"_ScaleUp", probability_ScaleUp)
-                    self.out.fillBranch("LHEMela_"+prob["Name"]+"_ScaleDown", probability_ScaleDown)
-                    self.out.fillBranch("LHEMela_"+prob["Name"]+"_SystUp", probability_SystUp)
-                    self.out.fillBranch("LHEMela_"+prob["Name"]+"_SystDown", probability_SystDown)
-
-
-                else:
-                    raise KeyError("Need to specify either production, decay, pm4l, or computeprop!")
+                    self.out.fillBranch(MELA_branchname+"_ScaleUp", probability_ScaleUp)
+                    self.out.fillBranch(MELA_branchname+"_ScaleDown", probability_ScaleDown)
+                    self.out.fillBranch(MELA_branchname+"_SystUp", probability_SystUp)
+                    self.out.fillBranch(MELA_branchname+"_SystDown", probability_SystDown)
+                elif MELA_computeprop==False :
+                    raise KeyError(f"LHEAngProbFiller: need to specify either (production and/or decay) or pm4l or computeprop for {MELA_Name}")
                 
-                if MELA_computeprop and (MELA_prod or MELA_dec): 
-                    probabilityprop = self.MELA.getXPropagator(MELA_propscheme)
-                    self.out.fillBranch("LHEMela_"+prob["Name"]+"_prop", probabilityprop)
-                elif MELA_computeprop: 
-                    probability = self.MELA.getXPropagator(MELA_propscheme)
+                if MELA_computeprop and not MELA_ispm4l:
+                    if (MELA_prod or MELA_dec): 
+                        probabilityprop = self.MELA.getXPropagator(MELA_propscheme)
+                        self.out.fillBranch(MELA_branchname+"_prop", probabilityprop)
+                    elif MELA_computeprop: 
+                        probability = self.MELA.getXPropagator(MELA_propscheme)
                 
                 # Handle divideP 
                 vprob[iprob] = probability
@@ -235,7 +237,7 @@ class LHEAngProbFiller(Module):
                         print("**LHEAngProbFiller: Protecting against division by 0!")
                 
 
-                self.out.fillBranch("LHEMela_"+prob["Name"], probability)
+                self.out.fillBranch(MELA_branchname, probability)
                 self.MELA.resetInputEvent()
         
        

--- a/NanoAnalysis/python/RecoProbFiller.py
+++ b/NanoAnalysis/python/RecoProbFiller.py
@@ -36,7 +36,7 @@ class RecoProbFiller(Module):
                 "match_mX":False,
                 "lepton_interference":"DefaultLeptonInterf",
                 "ispm4l": None,
-                "dividep": None 
+                "dividep": None
             }
 
             for prob in MELASettings:
@@ -50,7 +50,10 @@ class RecoProbFiller(Module):
                     else:
                         raise(ValueError(f"RecoProbFiller: unknown parameter {key} in {prob['Name']}"))
 
-                    ### Sort the MELASettings dictionary so that all probabilities with divideP are last 
+                # Add branch name so it does not need to be remade within loops
+                fprob["branchname"] = f"ZZCand_P_{prob['Name']}"
+                
+                ### Sort the MELASettings dictionary so that all probabilities with divideP are last 
                 if (fprob["dividep"]==None):
                     self.sortedSettings.insert(0,fprob)
                 else: 
@@ -60,7 +63,8 @@ class RecoProbFiller(Module):
             names = [d["Name"] for d in self.sortedSettings]
             for prob in self.sortedSettings:
                 dp = prob["dividep"]
-                prob["dividep_idx"] = (-1 if dp == None else names.index(dp))
+                prob["dividep_eval"] = (None if dp == None else f"aCand.P_{dp}") # string to be evaluated to extract denominator
+                # prob["dividep_idx"] = (-1 if dp == None else names.index(dp)) # prob index, more efficient but would require keeping probs for all cands
 
             print(f"***RecoProbFiller: probs: {names}", flush=True)
 
@@ -68,131 +72,125 @@ class RecoProbFiller(Module):
         self.out = wrappedOutputTree
         if len(self.sortedSettings) !=0 :
             for p, prob in enumerate(self.sortedSettings):
-                self.out.branch(f"ZZCand_P_{prob['Name']}", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level probability")
+                self.out.branch(prob["branchname"], "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level probability")
                 if prob.get("ispm4l", False):
                     self.out.branch("ZZCand_P_"+prob["Name"]+"_ScaleUp", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Scale uncertainties up")
-                    self.out.branch("ZZCand_P_"+prob["Name"]+"_ScaleDown", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Scale uncertainties down")
-                    self.out.branch("ZZCand_P_"+prob["Name"]+"_SystUp", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Systematic uncertainties up")
-                    self.out.branch("ZZCand_P_"+prob["Name"]+"_SystDown", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Systematic uncertainties down")
+                    self.out.branch(prob["branchname"]+"_ScaleDown", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Scale uncertainties down")
+                    self.out.branch(prob["branchname"]+"_SystUp", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Systematic uncertainties up")
+                    self.out.branch(prob["branchname"]+"_SystDown", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Systematic uncertainties down")
                 if prob["computeprop"]: 
-                    self.out.branch("ZZCand_P_"+prob["Name"]+"_prop", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level probability with non-default propagator scheme")
+                    self.out.branch(prob["branchname"]+"_prop", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level probability with non-default propagator scheme")
                         
 
         
     def analyze(self, event):
-        if len(self.sortedSettings) != 0 :
-            cands = Collection(event, 'ZZCand')
-            if len (cands) == 0 :
-                return True
-            electrons = Collection(event, "Electron")
-            muons = Collection(event, "Muon")
-            self.leps = list(electrons) + list(muons)
-            fsrPhotons = Collection(event, "FsrPhoton")
+        if len(self.sortedSettings)==0 or event.nZZCand==0: return True
+        cands = Collection(event, 'ZZCand')
+        leps = Collection(event, 'Lepton')
+        fsrPhotons = Collection(event, "FsrPhoton")
             
-            mothers = Mela.SimpleParticleCollection_t()
-            daughters = Mela.SimpleParticleCollection_t()
-            associated = Mela.SimpleParticleCollection_t()
+        # Cache the daughters for each candidate
+        candsDaughters = [Mela.SimpleParticleCollection_t()]*len(cands)
+        candsAssociated = [None]*len(cands) # FIXME to be added
+        for iCand, aCand in enumerate(cands):
+            theCandLepIdxs = [aCand.Z1l1Idx, aCand.Z1l2Idx, aCand.Z2l1Idx, aCand.Z2l2Idx]  
+            theCandLeps = [leps[i] for i in theCandLepIdxs]
+            dressedLepsp4 = [ZZExtraFiller.getDressedP4(self = None, lep = l, fsrPhotons=fsrPhotons) for l in theCandLeps]
+            daughters = candsDaughters[iCand]
+            associated = candsAssociated[iCand]
+            daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[0].pdgId, dressedLepsp4[0].Px(), dressedLepsp4[0].Py(), dressedLepsp4[0].Pz(), dressedLepsp4[0].E()))
+            daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[1].pdgId, dressedLepsp4[1].Px(), dressedLepsp4[1].Py(), dressedLepsp4[1].Pz(), dressedLepsp4[1].E()))
+            daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[2].pdgId, dressedLepsp4[2].Px(), dressedLepsp4[2].Py(), dressedLepsp4[2].Pz(), dressedLepsp4[2].E()))
+            daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[3].pdgId, dressedLepsp4[3].Px(), dressedLepsp4[3].Py(), dressedLepsp4[3].Pz(), dressedLepsp4[3].E()))
 
-            for iprob, prob in enumerate(self.sortedSettings):
-                vprob = [0.]*len(self.sortedSettings) # to be used to retrieve denominators for probs whith dividep
-                self.MELA.setInputEvent(daughters, None, None, 0)
-                
-                ### Parse MELA settings for the desired probability
-                MELA_Name = prob["Name"]
-                MELA_Process = check_enum(prob["Process"], Mela.Process)
-                MELA_MatrixElement = check_enum(prob["MatrixElement"], Mela.MatrixElement)
-                MELA_Production = check_enum(prob["Production"], Mela.Production)
-                MELA_prod = prob["Prod"]
-                MELA_dec = prob["Dec"]
-                MELA_computeprop = prob["computeprop"]
-                MELA_propscheme = check_enum(prob["propscheme"], Mela.ResonancePropagatorScheme)
-                MELA_separatewwzz = prob["separatewwzz"]
-                MELA_useconstant = prob["useconstant"]
-                MELA_matchMx = prob["match_mX"]
-                MELA_leptoninterference = check_enum(prob["lepton_interference"], Mela.LeptonInterference)
-                MELA_ispm4l = prob["ispm4l"]
-                MELA_divideP_idx = prob["dividep_idx"]
+        for iprob, prob in enumerate(self.sortedSettings):
+            ### Parse MELA settings for the desired probability
+            MELA_Name = prob["Name"]
+            MELA_Process = check_enum(prob["Process"], Mela.Process)
+            MELA_MatrixElement = check_enum(prob["MatrixElement"], Mela.MatrixElement)
+            MELA_Production = check_enum(prob["Production"], Mela.Production)
+            MELA_prod = prob["Prod"]
+            MELA_dec = prob["Dec"]
+            MELA_computeprop = prob["computeprop"]
+            MELA_propscheme = check_enum(prob["propscheme"], Mela.ResonancePropagatorScheme)
+            MELA_separatewwzz = prob["separatewwzz"]
+            MELA_useconstant = prob["useconstant"]
+            MELA_matchMx = prob["match_mX"]
+            MELA_leptoninterference = check_enum(prob["lepton_interference"], Mela.LeptonInterference)
+            MELA_ispm4l = prob["ispm4l"]
+            MELA_divideP_eval = prob["dividep_eval"]
+            MELA_branchname = prob["branchname"]
 
-                ### Configure MELA for the event. 
-                self.MELA.setProcess(MELA_Process, MELA_MatrixElement, MELA_Production)
-                self.MELA.differentiate_HWW_HZZ = MELA_separatewwzz
-                self.MELA.setMelaLeptonInterference(MELA_leptoninterference)                    
+            ### Configure MELA for the event. 
+            self.MELA.setProcess(MELA_Process, MELA_MatrixElement, MELA_Production)
+            self.MELA.differentiate_HWW_HZZ = MELA_separatewwzz
+            self.MELA.setMelaLeptonInterference(MELA_leptoninterference)                    
 
-                if MELA_matchMx: 
-                    self.MELA.setMelaHiggsMassWidth(daughters.MTotal(), 0.00001, 0)
-                    self.MELA.setMelaHiggsMassWidth(daughters.MTotal(), 0.00001, 1)
-                    
-                for coupl, coupl_val in prob["Couplings"].items(): 
-                    setattr(self.MELA, coupl, coupl_val) # FIXME: This needs to be reset at the beginning of the loop!
+            if MELA_matchMx: 
+                self.MELA.setMelaHiggsMassWidth(daughters.MTotal(), 0.00001, 0)
+                self.MELA.setMelaHiggsMassWidth(daughters.MTotal(), 0.00001, 1)
 
-                # Define an array to fill with a probability for each candidate
-                probVec = [-999.]*len(cands)
-                    
-                # Do so again for special cases where additional output is needed
-                if MELA_ispm4l: 
-                    probVec_ScaleUp = [-999.]*len(cands)
-                    probVec_ScaleDown = [-999.]*len(cands)
-                    probVec_SystUp = [-999.]*len(cands)
-                    probVec_SystDown = [-999.]*len(cands)
-                    
-                if MELA_computeprop and (MELA_prod or MELA_dec): 
-                    probPropVec = [-999.]*len(cands)
-                    
-                # Lifted from ZZExtraFiller 
-                for iCand, aCand in enumerate(cands):
-                    theCandLepIdxs = [aCand.Z1l1Idx, aCand.Z1l2Idx, aCand.Z2l1Idx, aCand.Z2l2Idx]
-                        
-                    theCandLeps = [self.leps[i] for i in theCandLepIdxs]
-                    dressedLepsp4 = [ZZExtraFiller.getDressedP4(self = None, lep = l, fsrPhotons=fsrPhotons) for l in theCandLeps]
-                    daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[0].pdgId, dressedLepsp4[0].Px(), dressedLepsp4[0].Py(), dressedLepsp4[0].Pz(), dressedLepsp4[0].E()))
-                    daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[1].pdgId, dressedLepsp4[1].Px(), dressedLepsp4[1].Py(), dressedLepsp4[1].Pz(), dressedLepsp4[1].E()))
-                    daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[2].pdgId, dressedLepsp4[2].Px(), dressedLepsp4[2].Py(), dressedLepsp4[2].Pz(), dressedLepsp4[2].E()))
-                    daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[3].pdgId, dressedLepsp4[3].Px(), dressedLepsp4[3].Py(), dressedLepsp4[3].Pz(), dressedLepsp4[3].E()))
-                    
-                    ### Reset the event and the default probability settings per probability to be calculated. 
-                    if MELA_prod and MELA_dec: 
-                        probVec[iCand] = self.MELA.computeProdDecP(MELA_useconstant)
-                    elif MELA_prod: 
-                        probVec[iCand] = self.MELA.computeProdP(MELA_useconstant)
-                    elif MELA_dec:
-                        probVec[iCand] = self.MELA.computeP(MELA_useconstant)
-                    elif MELA_ispm4l: 
-                        probVec[iCand] = self.MELA.computePM4L(Mela.SuperMelaSyst.SMSyst_None)
-                        probVec_ScaleUp[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ScaleUp)
-                        probVec_ScaleDown[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ScaleDown)
-                        probVec_SystUp[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResUp)
-                        probVec_SystDown[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResDown)
-                    else:
-                        raise KeyError(f"RecoProbFiller: {MELA_Name}: Need to specify either production, decay, pm4l, or computeprop!") # FIXME: then the next 2 cases should come before this else? 
-                        
-                    if MELA_computeprop and (MELA_prod or MELA_dec): 
+            for coupl, coupl_val in prob["Couplings"].items(): 
+                setattr(self.MELA, coupl, coupl_val)
+
+            # Define arrays to fill with the probabilites for each candidate
+            probVec = [-999.]*len(cands)
+            if MELA_ispm4l: 
+                probVec_ScaleUp = [-999.]*len(cands)
+                probVec_ScaleDown = [-999.]*len(cands)
+                probVec_SystUp = [-999.]*len(cands)
+                probVec_SystDown = [-999.]*len(cands)
+            if MELA_computeprop and (MELA_prod or MELA_dec): 
+                probPropVec = [-999.]*len(cands)
+
+            # Compute prob for each candidate
+            for iCand, aCand in enumerate(cands):
+                vprob = [0.]*len(self.sortedSettings) # to be used to retrieve denominators for probs whith dividep for the current cand
+
+                ### Reset the event and the default probability settings per probability to be calculated. 
+                self.MELA.setInputEvent(candsDaughters[iCand], candsAssociated[iCand], None, 0)
+
+                if MELA_prod and MELA_dec: 
+                    probVec[iCand] = self.MELA.computeProdDecP(MELA_useconstant)
+                elif MELA_prod: 
+                    probVec[iCand] = self.MELA.computeProdP(MELA_useconstant)
+                elif MELA_dec:
+                    probVec[iCand] = self.MELA.computeP(MELA_useconstant)
+                elif MELA_ispm4l: 
+                    probVec[iCand] = self.MELA.computePM4L(Mela.SuperMelaSyst.SMSyst_None)
+                    probVec_ScaleUp[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ScaleUp)
+                    probVec_ScaleDown[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ScaleDown)
+                    probVec_SystUp[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResUp)
+                    probVec_SystDown[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResDown)
+                elif MELA_computeprop==False :
+                    raise KeyError(f"RecoProbFiller: need to specify either (production and/or decay) or pm4l or computeprop for {MELA_Name}")
+
+                if MELA_computeprop and not MELA_ispm4l:
+                    if (MELA_prod or MELA_dec): 
                         probPropVec[iCand] = self.MELA.getXPropagator(MELA_propscheme)
                     elif MELA_computeprop: 
                         probVec[iCand] = self.MELA.getXPropagator(MELA_propscheme)
 
-                    # Handle divideP
-                    vprob[iprob] = probVec[iCand]
-                    if MELA_divideP_idx != -1:
-                        den = vprob[MELA_divideP_idx] #Because of prob sorting, this has already been computed
-                        if den != 0: 
-                            probVec[iCand] /= den
-                        else: 
-                            print("**RecoProbFiller: Protecting against division by 0.")
-                            
-                    ### Reset the input event on a per-candidate basis. 
-                    self.MELA.resetInputEvent()
+                # Handle divideP
+                vprob[iprob] = probVec[iCand]
+                if MELA_divideP_eval != None:
+                    den = eval(MELA_divideP_eval) #Because of prob sorting, this has already been stored
+                    if den != 0: 
+                        probVec[iCand] /= den
+                    else: 
+                        print("**RecoProbFiller: Protecting against division by 0.")
 
-                    # Write out all branches for this probability
-                    self.out.fillBranch("ZZCand_P_"+prob["Name"], probVec)
+            # Write out all branches for this probability
+            self.out.fillBranch(MELA_branchname, probVec)
 
-                    if MELA_ispm4l: 
-                        self.out.fillBranch("ZZCand_P_"+prob["Name"]+"_ScaleUp", probVec_ScaleUp)
-                        self.out.fillBranch("ZZCand_P_"+prob["Name"]+"_ScaleDown", probVec_ScaleDown)
-                        self.out.fillBranch("ZZCand_P_"+prob["Name"]+"_SystUp", probVec_SystUp)
-                        self.out.fillBranch("ZZCand_P_"+prob["Name"]+"_SystDown", probVec_SystDown)
+            if MELA_ispm4l: 
+                self.out.fillBranch(MELA_branchname+"_ScaleUp", probVec_ScaleUp)
+                self.out.fillBranch(MELA_branchname+"_ScaleDown", probVec_ScaleDown)
+                self.out.fillBranch(MELA_branchname+"_SystUp", probVec_SystUp)
+                self.out.fillBranch(MELA_branchname+"_SystDown", probVec_SystDown)
                     
-                    if MELA_computeprop and (MELA_prod or MELA_dec): 
-                        self.out.fillBranch("ZZCand_P_"+prob["Name"]+"_prop", probPropVec)
+            if MELA_computeprop and (MELA_prod or MELA_dec): 
+                self.out.fillBranch(MELA_branchname+"_prop", probPropVec)
         
         return True
     

--- a/NanoAnalysis/python/RecoProbFiller.py
+++ b/NanoAnalysis/python/RecoProbFiller.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import copy
 from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
 from  ZZAnalysis.NanoAnalysis.initializeMELA import check_enum
@@ -9,42 +10,80 @@ import Mela
 class RecoProbFiller(Module):
     """Calculates proabilities with Reco-level information. 
     MELA = Pointer to MELA passed from nanoZZ4lAnalysis.py 
+    MELASettings = dictionary with settings for the probabilities to be computed
     """
     
-    def __init__(self, MELA, NANOVERSION, settingsDict = None):
-        print("***RecoProbFiller", flush=True)
+    def __init__(self, MELA, NANOVERSION, MELASettings = None):
         self.MELA = MELA
-        self.MELAsettings = settingsDict
         self.NANOVERSION = NANOVERSION
-            
+        self.sortedSettings = []
+
+        if MELASettings != None:
+            defaults = {
+                "Name": "Default_You_Should_Rename_This",
+                "Process": None, 
+                "MatrixElement": None, 
+                "Production":None, 
+                "Prod": None, 
+                "Dec": None, 
+                "Couplings": None, 
+                "isgen": None, 
+                "computeprop": None, 
+                "propscheme": "FixedWidth", 
+                "decaymode": "CandidateDecay_ZZ",
+                "separatewwzz":False,
+                "useconstant":False,
+                "match_mX":False,
+                "lepton_interference":"DefaultLeptonInterf",
+                "ispm4l": False,
+                "dividep": None 
+            }
+
+            for prob in MELASettings:
+                if (prob["isgen"]): continue # Only calculate Reco-level probabilities in this module.
+
+                ### Merge specific settings with defaults and check for unsupported values
+                fprob=copy.deepcopy(defaults)
+                for key, value in prob.items():
+                    if key in defaults:
+                        fprob[key] = value
+                    else:
+                        raise(ValueError(f"RecoProbFiller: unknown parameter {key} in {prob['Name']}"))
+
+                    ### Sort the MELASettings dictionary so that all probabilities with divideP are last 
+                if (fprob["dividep"]==None):
+                    self.sortedSettings.insert(0,fprob)
+                else: 
+                    self.sortedSettings.append(fprob)
+
+            ### Create name-index dictionary, to retrieve the probabilities to be used for dividep.
+            self.namesDict = {}
+            for iprob, prob in enumerate(self.sortedSettings):
+                self.namesDict[prob["Name"]] = iprob
+
+            print(f"***RecoProbFiller: probs: {list(self.namesDict.keys())}", flush=True)
+
+
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
-        if self.MELAsettings != None: 
-            self.sortedSettings = []
-            self.denominator_name = ""
-            for p, prob in enumerate(self.MELAsettings):
-                if (prob["isgen"]) : continue 
-                ### Sort the MELASettings dictionary so that all probabilities with divideP are last 
-                if ("dividep" in prob) : 
-                    self.sortedSettings.append(prob)
-                    self.denominator_name = prob["dividep"]
-                else: 
-                    self.sortedSettings.insert(0,prob)
-                self.out.branch(f"ZZCand_RecoMela_{prob['Name']}", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level probability")
-                if prob.get("ispm4l", False): 
-                    self.out.branch("ZZCand_RecoMela_"+prob["Name"]+"_ScaleUp", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Scale uncertainties up")
-                    self.out.branch("ZZCand_RecoMela_"+prob["Name"]+"_ScaleDown", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Scale uncertainties down")
-                    self.out.branch("ZZCand_RecoMela_"+prob["Name"]+"_SystUp", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Systematic uncertainties up")
-                    self.out.branch("ZZCand_RecoMela_"+prob["Name"]+"_SystDown", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Systematic uncertainties down")
+        if len(self.sortedSettings) !=0 :
+            for p, prob in enumerate(self.sortedSettings):
+                self.out.branch(f"ZZCand_P_{prob['Name']}", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level probability")
+                if prob.get("ispm4l", False):
+                    self.out.branch("ZZCand_P_"+prob["Name"]+"_ScaleUp", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Scale uncertainties up")
+                    self.out.branch("ZZCand_P_"+prob["Name"]+"_ScaleDown", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Scale uncertainties down")
+                    self.out.branch("ZZCand_P_"+prob["Name"]+"_SystUp", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Systematic uncertainties up")
+                    self.out.branch("ZZCand_P_"+prob["Name"]+"_SystDown", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level m4l probability with Systematic uncertainties down")
                 if prob["computeprop"]: 
-                    self.out.branch("ZZCand_RecoMela_"+prob["Name"]+"_prop", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level probability with non-default propagator scheme")
+                    self.out.branch("ZZCand_P_"+prob["Name"]+"_prop", "F", lenVar = "nZZCand", limitedPrecision=16, title="User-defined Reco-level probability with non-default propagator scheme")
                         
 
         
     def analyze(self, event):
-        # Only run if we have a pyfragment 
-        if self.MELAsettings != None: 
+        if len(self.sortedSettings) != 0 :
             cands = Collection(event, 'ZZCand')
+            if len (cands) == 0 :
+                return True
             electrons = Collection(event, "Electron")
             muons = Collection(event, "Muon")
             self.leps = list(electrons) + list(muons)
@@ -54,170 +93,104 @@ class RecoProbFiller(Module):
             daughters = Mela.SimpleParticleCollection_t()
             associated = Mela.SimpleParticleCollection_t()
 
-            
+            for prob in self.sortedSettings:
+                self.MELA.setInputEvent(daughters, None, None, 0)
+                
+                ### Parse MELA settings for the desired probability
+                MELA_Name = prob["Name"]
+                MELA_Process = check_enum(prob["Process"], Mela.Process)
+                MELA_MatrixElement = check_enum(prob["MatrixElement"], Mela.MatrixElement)
+                MELA_Production = check_enum(prob["Production"], Mela.Production)
+                MELA_prod = prob["Prod"]
+                MELA_dec = prob["Dec"]
+                MELA_computeprop = prob["computeprop"]
+                MELA_propscheme = check_enum(prob["propscheme"], Mela.ResonancePropagatorScheme)
+                MELA_separatewwzz = prob["separatewwzz"]
+                MELA_useconstant = prob["useconstant"]
+                MELA_matchMx = prob["match_mX"]
+                MELA_leptoninterference = check_enum(prob["lepton_interference"], Mela.LeptonInterference)
+                MELA_ispm4l = prob["ispm4l"]
+                MELA_divideP = prob["dividep"]
 
+                ### Configure MELA for the event. 
+                self.MELA.setProcess(MELA_Process, MELA_MatrixElement, MELA_Production)
+                self.MELA.differentiate_HWW_HZZ = MELA_separatewwzz
+                self.MELA.setMelaLeptonInterference(MELA_leptoninterference)                    
 
-            for p, prob in enumerate(self.sortedSettings):
-                ### Only calculate Reco-level probabilities in this function. 
-                if prob["isgen"] == False: 
-                    ### Define parameters for the probability to be computed. They don't need to be changed on a per-candidate level. 
-                    self.MELA.setInputEvent(daughters, None, None, 0)
-                    setupInputs = {
-                            "Name": "Default_You_Should_Rename_This",
-                            "Process": None, 
-                            "MatrixElement": None, 
-                            "Production":None, 
-                            "Prod": None, 
-                            "Dec": None, 
-                            "Couplings": None, 
-                            "isgen": None, 
-                            "computeprop": None, 
-                            "propscheme": "FixedWidth", 
-                            "decaymode": "CandidateDecay_ZZ",
-                            "separatewwzz":False,
-                            "useconstant":False,
-                            "match_mX":False,
-                            "lepton_interference":"DefaultLeptonInterf",
-                            "ispm4l": None,
-                            "dividep": None 
-                        }
+                if MELA_matchMx: 
+                    self.MELA.setMelaHiggsMassWidth(daughters.MTotal(), 0.00001, 0)
+                    self.MELA.setMelaHiggsMassWidth(daughters.MTotal(), 0.00001, 1)
+                    
+                for coupl, coupl_val in prob["Couplings"].items(): 
+                    setattr(self.MELA, coupl, coupl_val) # FIXME: This needs to be reset at the beginning of the loop!
+
+                # Define an array to fill with a probability for each candidate
+                probVec = [-999.]*len(cands)
+                    
+                # Do so again for special cases where additional output is needed
+                if MELA_ispm4l: 
+                    probVec_ScaleUp = [-999.]*len(cands)
+                    probVec_ScaleDown = [-999.]*len(cands)
+                    probVec_SystUp = [-999.]*len(cands)
+                    probVec_SystDown = [-999.]*len(cands)
+                    
+                if MELA_computeprop and (MELA_prod or MELA_dec): 
+                    probPropVec = [-999.]*len(cands)
+                    
+                # Lifted from ZZExtraFiller 
+                for iCand, aCand in enumerate(cands):
+                    theCandLepIdxs = [aCand.Z1l1Idx, aCand.Z1l2Idx, aCand.Z2l1Idx, aCand.Z2l2Idx]
                         
-                    ### Parse MELA settings for the desired probability and overwrite setup for all given parameters:
-                    for key, val in prob.items(): setupInputs[key] = prob[key]
-
+                    theCandLeps = [self.leps[i] for i in theCandLepIdxs]
+                    dressedLepsp4 = [ZZExtraFiller.getDressedP4(self = None, lep = l, fsrPhotons=fsrPhotons) for l in theCandLeps]
+                    daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[0].pdgId, dressedLepsp4[0].Px(), dressedLepsp4[0].Py(), dressedLepsp4[0].Pz(), dressedLepsp4[0].E()))
+                    daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[1].pdgId, dressedLepsp4[1].Px(), dressedLepsp4[1].Py(), dressedLepsp4[1].Pz(), dressedLepsp4[1].E()))
+                    daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[2].pdgId, dressedLepsp4[2].Px(), dressedLepsp4[2].Py(), dressedLepsp4[2].Pz(), dressedLepsp4[2].E()))
+                    daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[3].pdgId, dressedLepsp4[3].Px(), dressedLepsp4[3].Py(), dressedLepsp4[3].Pz(), dressedLepsp4[3].E()))
                     
-
-                    ### Define everything 
-                    MELA_Name = setupInputs["Name"]
-                    MELA_Process = check_enum(setupInputs["Process"], Mela.Process)
-                    MELA_MatrixElement = check_enum(setupInputs["MatrixElement"], Mela.MatrixElement)
-                    MELA_Production = check_enum(setupInputs["Production"], Mela.Production)
-                    MELA_prod = setupInputs["Prod"]
-                    MELA_dec = setupInputs["Dec"]
-                    MELA_computeprop = setupInputs["computeprop"]
-                    MELA_propscheme = check_enum(setupInputs["propscheme"], Mela.ResonancePropagatorScheme)
-                    MELA_separatewwzz = setupInputs["separatewwzz"]
-                    MELA_useconstant = setupInputs["useconstant"]
-                    MELA_matchMx = setupInputs["match_mX"]
-                    MELA_leptoninterference = check_enum(setupInputs["lepton_interference"], Mela.LeptonInterference)
-                    MELA_ispm4l = setupInputs["ispm4l"]
-                    MELA_divideP = setupInputs["dividep"]
-
-                    ### Configure MELA for the event. 
-                    self.MELA.setProcess(MELA_Process, MELA_MatrixElement, MELA_Production)
-                    self.MELA.differentiate_HWW_HZZ = MELA_separatewwzz
-                    self.MELA.setMelaLeptonInterference(MELA_leptoninterference)
-
-                    
-
-                    if MELA_matchMx: 
-                        self.MELA.setMelaHiggsMassWidth(daughters.MTotal(), 0.00001, 0)
-                        self.MELA.setMelaHiggsMassWidth(daughters.MTotal(), 0.00001, 1)
-                    
-                    for coupl, coupl_val in setupInputs["Couplings"].items(): 
-                        setattr(self.MELA, coupl, coupl_val)
-
-                    # Define an array to fill with a probability for each candidate
-                    probVec = [-999.]*len(cands)
-                    
-
-                    if MELA_Name == self.denominator_name: 
-                        denomVec = [-999.]*len(cands)
-                    # Do so again for special cases where additional output is needed
-                    if MELA_ispm4l: 
-                        probVec_ScaleUp = [-999.]*len(cands)
-                        probVec_ScaleDown = [-999.]*len(cands)
-                        probVec_SystUp = [-999.]*len(cands)
-                        probVec_SystDown = [-999.]*len(cands)
-                    
+                    ### Reset the event and the default probability settings per probability to be calculated. 
+                    if MELA_prod and MELA_dec: 
+                        probVec[iCand] = self.MELA.computeProdDecP(MELA_useconstant)
+                    elif MELA_prod: 
+                        probVec[iCand] = self.MELA.computeProdP(MELA_useconstant)
+                    elif MELA_dec:
+                        probVec[iCand] = self.MELA.computeP(MELA_useconstant)
+                    elif MELA_ispm4l: 
+                        probVec[iCand] = self.MELA.computePM4L(Mela.SuperMelaSyst.SMSyst_None)
+                        probVec_ScaleUp[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ScaleUp)
+                        probVec_ScaleDown[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ScaleDown)
+                        probVec_SystUp[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResUp)
+                        probVec_SystDown[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResDown)
+                    else:
+                        raise KeyError(f"RecoProbFiller: {MELA_Name}: Need to specify either production, decay, pm4l, or computeprop!")
+                        
                     if MELA_computeprop and (MELA_prod or MELA_dec): 
-                        probPropVec = [-999.]*len(cands)
-                    
-                    
-                    # Lifted from ZZExtraFiller 
-                    for iCand, aCand in enumerate(cands):
-                        theCandLepIdxs = [aCand.Z1l1Idx, aCand.Z1l2Idx, aCand.Z2l1Idx, aCand.Z2l2Idx]
+                        probPropVec[iCand] = self.MELA.getXPropagator(MELA_propscheme)
+                    elif MELA_computeprop: 
+                        probVec[iCand] = self.MELA.getXPropagator(MELA_propscheme)
 
-                        
-                        theCandLeps = [self.leps[i] for i in theCandLepIdxs] 
-                        
-                        
-                        dressedLepsp4 = [ZZExtraFiller.getDressedP4(self = None, lep = l, fsrPhotons=fsrPhotons) for l in theCandLeps]
-
-                        daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[0].pdgId, dressedLepsp4[0].Px(), dressedLepsp4[0].Py(), dressedLepsp4[0].Pz(), dressedLepsp4[0].E()))
+                    # Handle divideP
+                    if MELA_divideP != None:
+                        den = probVec[self.namesDict[MELA_divideP]]
+                        if den != 0: 
+                            probVec[iCand] /= den
+                        else: 
+                            print("**RecoProbFiller: Protecting against division by 0.")
                             
-                        daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[1].pdgId, dressedLepsp4[1].Px(), dressedLepsp4[1].Py(), dressedLepsp4[1].Pz(), dressedLepsp4[1].E()))
-
-                        daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[2].pdgId, dressedLepsp4[2].Px(), dressedLepsp4[2].Py(), dressedLepsp4[2].Pz(), dressedLepsp4[2].E()))
-
-                        daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[3].pdgId, dressedLepsp4[3].Px(), dressedLepsp4[3].Py(), dressedLepsp4[3].Pz(), dressedLepsp4[3].E()))
-                        
-                        ### Reset the event and the default probability settings per probability to be calculated. 
-                        if MELA_prod and MELA_dec: 
-                            probVec[iCand] = self.MELA.computeProdDecP(MELA_useconstant)
-                        elif MELA_prod: 
-                            probVec[iCand] = self.MELA.computeProdP(MELA_useconstant)
-                        elif MELA_dec:
-                            probVec[iCand] = self.MELA.computeP(MELA_useconstant)
-                        elif MELA_ispm4l: 
-                            probVec[iCand] = self.MELA.computePM4L(Mela.SuperMelaSyst.SMSyst_None)
-                            probVec_ScaleUp[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ScaleUp)
-                            probVec_ScaleDown[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ScaleDown)
-                            probVec_SystUp[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResUp)
-                            probVec_SystDown[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResDown)
-
-                            
-
-
-                        else:
-                            raise KeyError("Need to specify either production, decay, pm4l, or computeprop!")
-                        
-                        if MELA_computeprop and (MELA_prod or MELA_dec): 
-                            probPropVec[iCand] = self.MELA.getXPropagator(MELA_propscheme)
-
-                        elif MELA_computeprop: 
-                            probVec[iCand] = self.MELA.getXPropagator(MELA_propscheme)
-                        
-
-
-                        # Handling divideP 
-                        if MELA_Name == self.denominator_name: 
-                            denomVec[iCand] = probVec[iCand]
-                        
-                        if MELA_divideP != None: 
-                            if denomVec[iCand] != 0: 
-                                probVec[iCand] /= denomVec[iCand]
-                            else: 
-                                print("**RecoProbFiller: Protecting against division by 0.")
-
-
-
-                        
-                        
-                        
-                        
-                        
-
-                            
-                        ### Reset the input event on a per-candidate basis. 
-                        self.MELA.resetInputEvent()
+                    ### Reset the input event on a per-candidate basis. 
+                    self.MELA.resetInputEvent()
 
                     # Write out all branches for this probability
-                    self.out.fillBranch("ZZCand_RecoMela_"+prob["Name"], probVec)
+                    self.out.fillBranch("ZZCand_P_"+prob["Name"], probVec)
 
                     if MELA_ispm4l: 
-                        self.out.fillBranch("ZZCand_RecoMela_"+setupInputs["Name"]+"_ScaleUp", probVec_ScaleUp)
-                        self.out.fillBranch("ZZCand_RecoMela_"+setupInputs["Name"]+"_ScaleDown", probVec_ScaleDown)
-                        self.out.fillBranch("ZZCand_RecoMela_"+setupInputs["Name"]+"_SystUp", probVec_SystUp)
-                        self.out.fillBranch("ZZCand_RecoMela_"+setupInputs["Name"]+"_SystDown", probVec_SystDown)
+                        self.out.fillBranch("ZZCand_P_"+prob["Name"]+"_ScaleUp", probVec_ScaleUp)
+                        self.out.fillBranch("ZZCand_P_"+prob["Name"]+"_ScaleDown", probVec_ScaleDown)
+                        self.out.fillBranch("ZZCand_P_"+prob["Name"]+"_SystUp", probVec_SystUp)
+                        self.out.fillBranch("ZZCand_P_"+prob["Name"]+"_SystDown", probVec_SystDown)
                     
                     if MELA_computeprop and (MELA_prod or MELA_dec): 
-                        self.out.fillBranch("ZZCand_RecoMela_"+setupInputs["Name"]+"_prop", probPropVec)
-
-
-
-       
-        
+                        self.out.fillBranch("ZZCand_P_"+prob["Name"]+"_prop", probPropVec)
         
         return True
     

--- a/NanoAnalysis/python/RecoProbFiller.py
+++ b/NanoAnalysis/python/RecoProbFiller.py
@@ -35,7 +35,7 @@ class RecoProbFiller(Module):
                 "useconstant":False,
                 "match_mX":False,
                 "lepton_interference":"DefaultLeptonInterf",
-                "ispm4l": False,
+                "ispm4l": None,
                 "dividep": None 
             }
 
@@ -56,13 +56,13 @@ class RecoProbFiller(Module):
                 else: 
                     self.sortedSettings.append(fprob)
 
-            ### Create name-index dictionary, to retrieve the probabilities to be used for dividep.
-            self.namesDict = {}
-            for iprob, prob in enumerate(self.sortedSettings):
-                self.namesDict[prob["Name"]] = iprob
+            ### Add index of probability to be used for dividep.
+            names = [d["Name"] for d in self.sortedSettings]
+            for prob in self.sortedSettings:
+                dp = prob["dividep"]
+                prob["dividep_idx"] = (-1 if dp == None else names.index(dp))
 
-            print(f"***RecoProbFiller: probs: {list(self.namesDict.keys())}", flush=True)
-
+            print(f"***RecoProbFiller: probs: {names}", flush=True)
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
@@ -93,7 +93,8 @@ class RecoProbFiller(Module):
             daughters = Mela.SimpleParticleCollection_t()
             associated = Mela.SimpleParticleCollection_t()
 
-            for prob in self.sortedSettings:
+            for iprob, prob in enumerate(self.sortedSettings):
+                vprob = [0.]*len(self.sortedSettings) # to be used to retrieve denominators for probs whith dividep
                 self.MELA.setInputEvent(daughters, None, None, 0)
                 
                 ### Parse MELA settings for the desired probability
@@ -110,7 +111,7 @@ class RecoProbFiller(Module):
                 MELA_matchMx = prob["match_mX"]
                 MELA_leptoninterference = check_enum(prob["lepton_interference"], Mela.LeptonInterference)
                 MELA_ispm4l = prob["ispm4l"]
-                MELA_divideP = prob["dividep"]
+                MELA_divideP_idx = prob["dividep_idx"]
 
                 ### Configure MELA for the event. 
                 self.MELA.setProcess(MELA_Process, MELA_MatrixElement, MELA_Production)
@@ -162,7 +163,7 @@ class RecoProbFiller(Module):
                         probVec_SystUp[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResUp)
                         probVec_SystDown[iCand] = self.MELA.computePM4l(Mela.SuperMelaSyst.SMSyst_ResDown)
                     else:
-                        raise KeyError(f"RecoProbFiller: {MELA_Name}: Need to specify either production, decay, pm4l, or computeprop!")
+                        raise KeyError(f"RecoProbFiller: {MELA_Name}: Need to specify either production, decay, pm4l, or computeprop!") # FIXME: then the next 2 cases should come before this else? 
                         
                     if MELA_computeprop and (MELA_prod or MELA_dec): 
                         probPropVec[iCand] = self.MELA.getXPropagator(MELA_propscheme)
@@ -170,8 +171,9 @@ class RecoProbFiller(Module):
                         probVec[iCand] = self.MELA.getXPropagator(MELA_propscheme)
 
                     # Handle divideP
-                    if MELA_divideP != None:
-                        den = probVec[self.namesDict[MELA_divideP]]
+                    vprob[iprob] = probVec[iCand]
+                    if MELA_divideP_idx != -1:
+                        den = vprob[MELA_divideP_idx] #Because of prob sorting, this has already been computed
                         if den != 0: 
                             probVec[iCand] /= den
                         else: 

--- a/NanoAnalysis/python/initializeMELA.py
+++ b/NanoAnalysis/python/initializeMELA.py
@@ -1,11 +1,8 @@
 import Mela
 
 
-
-### initializes a pointer to a MELA object given parameters set by the user. 
-def initializeMELA(runMELA, year, probabilities=None): 
-
-   
+def initializeMELA(runMELA, year):
+    """initializes a pointer to a MELA object."""
     if runMELA == True:
         sqrts = 13. 
         if year >= 2022:
@@ -21,17 +18,9 @@ def initializeMELA(runMELA, year, probabilities=None):
         os.close(devnull)
         os.close(saved_stdout)
         print(f"***initializeMELA: created Mela({sqrts:.1f},125,TVar.CandidateDecay_ZZ)", flush=True)
-        ### If at least one of the essential settings to calculate probabilities are set, make clear that only angles will be computed. 
-        if probabilities == None: 
-            print("***initializeMELA: No probabilities have been given. Only angles will be computed.")
-            probSettingsDict = None
-        else: 
-            probSettingsDict = probabilities 
-
     else: 
         m = None
-        probSettingsDict = None
-    return m, probSettingsDict
+    return m
 
 
 

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -175,7 +175,6 @@ if not IsMC :
 ### Modules to be run
 
 # Standard sequence used for both data and MC
-from ZZAnalysis.NanoAnalysis.RecoProbFiller import * 
 reco_sequence = [lepFiller(cuts, LEPTON_SETUP, MUON_ID_BYMVA), # FSR and FSR-corrected iso; flags for passing IDs
                  ZZFiller(bestCandByMELA, mela,
                           isMC=IsMC,
@@ -191,6 +190,7 @@ reco_sequence = [lepFiller(cuts, LEPTON_SETUP, MUON_ID_BYMVA), # FSR and FSR-cor
                  ]
 
 if MELAprobabilities != None:
+    from ZZAnalysis.NanoAnalysis.RecoProbFiller import *
     reco_sequence.append(RecoProbFiller(mela, NANOVERSION, melaSettings))  #Reco level probabilities. 
 
 # Add muon scale corrections

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -70,7 +70,7 @@ CANDSTOSTORE = getConf("CANDSTOSTORE", 'BestCandOnly') # which candidates should
                                                   # CR that is activated, only the best candidate is stored.
 
 # MELA Probabilities Dictionary:
-MELAprobabilities = getConf("probabilities", None)
+melaSettings = getConf("probabilities", None)
 
 # Process customizations - list of functions that operate on process
 customizations = getConf("customizations", [])
@@ -80,7 +80,7 @@ genXS = getConf("GENXSEC", 1.)
 genBR = getConf("GENBR", 1.)
 
 from ZZAnalysis.NanoAnalysis.initializeMELA import * 
-mela, melaSettings = initializeMELA(runMELA, LEPTON_SETUP, probabilities=MELAprobabilities)
+mela = initializeMELA(runMELA, LEPTON_SETUP)
                                                   
 ### Definition of analysis cuts
 cuts = dict(
@@ -189,7 +189,7 @@ reco_sequence = [lepFiller(cuts, LEPTON_SETUP, MUON_ID_BYMVA), # FSR and FSR-cor
                  ZZExtraFiller(mela, IsMC, LEPTON_SETUP, DATA_TAG, PROCESS_CR), # Additional variables to selected candidates
                  ]
 
-if MELAprobabilities != None:
+if melaSettings != None:
     from ZZAnalysis.NanoAnalysis.RecoProbFiller import *
     reco_sequence.append(RecoProbFiller(mela, NANOVERSION, melaSettings))  #Reco level probabilities. 
 

--- a/NanoAnalysis/test/prod/pyFragments/exampleProbabilities.py
+++ b/NanoAnalysis/test/prod/pyFragments/exampleProbabilities.py
@@ -58,7 +58,7 @@ setConf("probabilities", {'Name': "Native",
                           }, 
                           append=True)
 
-setConf("probabilities", {'Name': "P_Gen_ggH_ghg2_1_ghz4_1", 
+setConf("probabilities", {'Name': "ggH_ghg2_1_ghz4_1", 
                         "Process": "SelfDefine_spin0", 
                         "MatrixElement":"JHUGen",
                         "Production": "ZZGG", 


### PR DESCRIPTION
- Improvements in the implementation of `LHEAngProbFiller` and `RecoProbFiller`: 
   - Sorted settings are now merged with defaults once in the constructor, and not for each event/prob
   - A check is also made on the parameters to detect any misspelled or unexpected one 
   - The mechanism for handling `dividep` is changed. In the [original version](https://github.com/CJLST/ZZAnalysis/blob/11f5cec598bd3338d738c854b16db2baf5d5a86d/NanoAnalysis/python/RecoProbFiller.py#L30), `dividep` is implicitly assumed to be a per-process setting, but in the probabilities specification, it is a per-probability one, and there is no guarantee that a set of probabilities (possibly obtained from combining several pyFragments) has all `dividep` values to be identical when different than `None`. In this PR'simplementation, each probabiliy is divided by the value of its own `dividep`, even if they are not the same.
   - Naming scheme changed; probabilities are now forced to be called `LHEMela_P_*` and `ZZCand_P_*`. Existing fragments should be updated accordingly (notably, removing the leading `P_`)
   - Clean up percolation of MELAProbabilities through `initializeMELA`
   - Note: limited testing (only using `exampleProbabilities.py`)
   - Future developments:
      - Extend  the `isGen` parameter with the option of specify that a probability has to be computed for both gen and reco
      - Move the computation of RECO angles from `ZZExtraFiller` to `RecoProbFiller`
      - Extract the actual computation code that is common to LHE and RECO codes into a function called by both, to avoid code duplication
      - Add handling of CRs in `RecoProbFiller`
- Added experimental Dataset helper, to present a set of Chunks as if they were a single TFile, without hadding.
