### PR TITLE
First updates for Run2 v15 samples

### DIFF
--- a/NanoAnalysis/python/getEleBDTCut.py
+++ b/NanoAnalysis/python/getEleBDTCut.py
@@ -6,8 +6,8 @@
 ##
 
 def getEleBDTCut(era, dataTag, nanoVersion, useUncorrPt=False) :
-    # nanoAODv9 includes mvaFall17V2Iso = 2017 WP and training (ElectronMVAEstimatorRun2Fall17IsoV2Values)
 
+    # nanoAODv9 and older include only mvaFall17V2Iso = 2017 WP and training (ElectronMVAEstimatorRun2Fall17IsoV2Values), for all years
     def eleBDTCut_RunIIpreUL_v9(ele) :
         # pre-UL WP for Run II (miniAOD branch: Run2_CutBased_BTag16)
         fSCeta = abs(ele.eta + ele.deltaEtaSC)
@@ -30,6 +30,35 @@ def getEleBDTCut(era, dataTag, nanoVersion, useUncorrPt=False) :
                                      (fSCeta>=0.8 and fSCeta<1.479 and BDT > 0.0273863727) or \
                                      (fSCeta>=1.479                and BDT > -0.5532483665)))
 
+    def eleBDTCut_RunII2016UL_v15(ele) :
+        fSCeta = ele.superclusterEta
+        BDT = ele.mvaHZZIso
+        return (ele.pt<=10. and     ((fSCeta<0.8                   and BDT > 0.9557993256) or \
+                                     (fSCeta>=0.8 and fSCeta<1.479 and BDT > 0.9475406570) or \
+                                     (fSCeta>=1.479                and BDT > 0.9285158721))) \
+                or (ele.pt>10. and  ((fSCeta<0.8                   and BDT > 0.3272075608) or \
+                                     (fSCeta>=0.8 and fSCeta<1.479 and BDT > 0.2468345995) or \
+                                     (fSCeta>=1.479                and BDT > -0.5955762814)))
+
+    def eleBDTCut_RunII2017UL_v15(ele) :
+        fSCeta = ele.superclusterEta
+        BDT = ele.mvaHZZIso
+        return (ele.pt<=10. and     ((fSCeta<0.8                   and BDT > 0.9128577458 ) or \
+                                     (fSCeta>=0.8 and fSCeta<1.479 and BDT > 0.9056792368 ) or \
+                                     (fSCeta>=1.479                and BDT > 0.9439440575 ))) \
+                or (ele.pt>10. and  ((fSCeta<0.8                   and BDT > 0.1559788054 ) or \
+                                     (fSCeta>=0.8 and fSCeta<1.479 and BDT > 0.0273863727 ) or \
+                                     (fSCeta>=1.479                and BDT > -0.5532483665)))
+
+    def eleBDTCut_RunII2018UL_v15(ele) :
+        fSCeta = ele.superclusterEta
+        BDT = ele.mvaHZZIso
+        return (ele.pt<=10. and     ((fSCeta<0.8                   and BDT > 0.9044286167) or \
+                                     (fSCeta>=0.8 and fSCeta<1.479 and BDT > 0.9094166886) or \
+                                     (fSCeta>=1.479                and BDT > 0.9443653660))) \
+                or (ele.pt>10. and  ((fSCeta<0.8                   and BDT > 0.1968600840) or \
+                                     (fSCeta>=0.8 and fSCeta<1.479 and BDT > 0.0759172100) or \
+                                     (fSCeta>=1.479                and BDT > -0.5169136775)))
 
     # Run3 nanoAODv12 samples have the 2018 UL tuning (ElectronMVAEstimatorRun2Summer18ULIdIsoValues)
     # The WP was derived before scale corrections, so the uncorrected pt should be used when available.
@@ -49,13 +78,20 @@ def getEleBDTCut(era, dataTag, nanoVersion, useUncorrPt=False) :
 
     def eleBDTCut_RunIII_2022Training_WP(ele):
         return ele.mvaIso_WPHZZ
-    if era == 2017 or era == 2018 :
-        if "UL" in dataTag :
-            if nanoVersion <10 :
+
+    
+    if era >= 2016 and era <= 2018 :
+        if nanoVersion < 10 :
+            if "UL" in dataTag :
                 return eleBDTCut_RunIIUL_v9
-        else :
-            if nanoVersion <10 :
+            else :
                 return eleBDTCut_RunIIpreUL_v9
+        elif nanoVersion == 15 :
+            cutsv15 = {2016: eleBDTCut_RunII2016UL_v15, 2017: eleBDTCut_RunII2017UL_v15, 2018: eleBDTCut_RunII2018UL_v15}
+            return cutsv15[era]
+        else :
+            raise ValueError('getEleBDTCut: era '+ str(era)+', dataTag ' + dataTag + ', nanoVersion ' + str(nanoVersion) + ' not supported')
+          
 
     elif era >=2022 :
         if nanoVersion <14:

--- a/NanoAnalysis/python/mcHistoryDump.py
+++ b/NanoAnalysis/python/mcHistoryDump.py
@@ -8,11 +8,12 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collect
 from prettytable import PrettyTable
 
 class mcHistoryDump(Module):
-    def __init__(self, printGen=True, printLHE=False) :
+    def __init__(self, printGen=True, printLHE=False, nanoversion=12) :
         """Print Gen history and LHE particles.
         """ 
         self.printGen=printGen
         self.printLHE=printLHE
+        self.nanoversion = nanoversion
 
     def analyze(self, event):
         if self.printGen :
@@ -50,10 +51,16 @@ class mcHistoryDump(Module):
         '''Print LHE particle history on output
         '''
 
-        print("---LHEPart---") 
-        table = PrettyTable(['i', 'pdgId', 'pT', 'eta', 'phi', 'status', 'incomingpz'])
+        print("---LHEPart---")
+        if self.nanoversion<15:
+            table = PrettyTable(['i', 'pdgId', 'pT', 'eta', 'phi', 'status', 'incomingpz'])
+        else:
+            table = PrettyTable(['i', 'pdgId', 'mother', 'pT', 'eta', 'phi', 'status', 'incomingpz'])
         for i, Lp in enumerate(LHEPart):
-            table.add_row([self.format_value(val) for val in [i, Lp.pdgId, Lp.pt, Lp.eta, Lp.mass, Lp.status, Lp.incomingpz]])
+            if self.nanoversion<15:
+                table.add_row([self.format_value(val) for val in [i, Lp.pdgId, Lp.pt, Lp.eta, Lp.mass, Lp.status, Lp.incomingpz]])
+            else:
+                table.add_row([self.format_value(val) for val in [i, Lp.pdgId, Lp.firstMotherIdx, Lp.pt, Lp.eta, Lp.mass, Lp.status, Lp.incomingpz]])
         for col in table.field_names:
             table.align[col] = "l"
         print(table)

--- a/NanoAnalysis/python/modules/jetIdProducer.py
+++ b/NanoAnalysis/python/modules/jetIdProducer.py
@@ -4,25 +4,30 @@ Instantiate jetId correctionlib module (for nanoAODv13 onwards, cf. https://gitl
 
 def getJetIdProducer(era, tag) :
     from PhysicsTools.NATModules.modules.jetId import jetId
-    if era not in [2022,2023,2024]:
-        raise ValueError("getJetIdProducer: get: Era", era, "not supported")
-
+    
     if era == 2022:
         if "pre_EE" in tag:
-            folderKey = "2022_Summer22" #md5sum: 2070556451837fe611d6e0b0218a5d1f
+            json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22/jetid.json.gz" #md5sum: 2070556451837fe611d6e0b0218a5d1f
         else:
-            folderKey = "2022_Summer22EE" # Note: file is a link to the 2022_Summer22 file
+            json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22EE/jetid.json.gz" # Note: file is a link to the 2022_Summer22 file
     
     elif era == 2023:
         if "pre_BPix" in tag:
-            folderKey = "2023_Summer23" # Note: file is a link to the 2022_Summer22 file
+            json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2023_Summer23/jetid.json.gz" # Note: file is a link to the 2022_Summer22 file
         else:
-            folderKey = "2023_Summer23BPix" # Note: file is a link to the 2022_Summer22 file
+            json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2023_Summer23BPix/jetid.json.gz" # Note: file is a link to the 2022_Summer22 file
 
     elif era == 2024:
-       folderKey = "2024_Summer24" # Note: file is a link to the 2022_Summer22 file
+       json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-07-17/jetid.json.gz" #from new versioned repository; identical to 2022_Summer22
 
-    json = f"/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/{folderKey}/jetid.json.gz"
+    elif era >= 2016 and era <=2018:
+        # FIXME: Assume the same as 2022_Summer22 since json file is not present in official repositories
+        print("WARNING: official jetid json not available, using the one for 2022_Summer22")
+        json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22/jetid.json.gz"
+
+    else: 
+        raise ValueError("getJetIdProducer: get: Era", era, tag, "not supported")  
+
     print("***jetId: era:", era, "tag:", tag, "json:", json)
        
     return jetId(json)

--- a/NanoAnalysis/python/modules/jetJERC.py
+++ b/NanoAnalysis/python/modules/jetJERC.py
@@ -1,8 +1,6 @@
 def getJetCorrected(era, tag, is_mc, overwritePt=True) :
     from PhysicsTools.NATModules.modules.jetCorr import jetJERC
 
-    if era not in [2022, 2023, 2024]:
-        raise ValueError("getJetCorrected: Era", era, "not supported")
 
 # Regrouped uncertainties (11 sources) - The {year} part indicates those uncertainties that need to be kept uncorrelated between these datasets.
 # Taken from https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/-/merge_requests/120#9968ad259fd43c9ba2351d217c42dec468fe273f
@@ -20,7 +18,43 @@ def getJetCorrected(era, tag, is_mc, overwritePt=True) :
         "Regrouped_RelativeSample_{year}",
     ]
 
-    if era == 2022:
+    if era == 2016 and "UL" in tag:
+        if "ULAPV" in tag:
+            pass
+        else:
+            pass
+        raise ValueError("jetJERC: 2016 to be implemented")
+    elif era == 2017 and "UL" in tag:
+        raise ValueError("jetJERC: 2017 to be implemented")
+    elif era == 2018 and  "UL" in tag:
+        # FIXME: to be confirmed that v9 corrections are to be used for v15 as well
+        folderKey = "Run2-2018-UL-NanoAODv9/2025-04-11"
+        if is_mc :
+            L1Key = "Summer19UL18_V5_MC_L1FastJet_AK4PFchs"
+            L2Key = "Summer19UL18_V5_MC_L2Relative_AK4PFchs"
+            L3Key = "Summer19UL18_V5_MC_L3Absolute_AK4PFchs"
+            L2L3Key = "Summer19UL18_V5_MC_L2L3Residual_AK4PFchs"
+            scaleTotalKey = "Summer19UL18_V5_MC_Total_AK4PFchs"
+            scaleKeyRegrouped11 = [
+                f"Summer19UL18_V5_MC_{label.format(year='2018')}_AK4PFchs" for label in jes_systematics_11split
+                ]
+            smearKey = "JERSmear"
+            # It appears the most recent 23Bpix files are used in the following cases: 
+            JERKey = "Summer19UL18_JRV2_MC_PtResolution_AK4PFchs"
+            JERsfKey = "Summer19UL18_JRV2_MC_ScaleFactor_AK4PFchs"
+ 
+        else :
+            L1Key = "Summer19UL18_RunA_V5_DATA_L1FastJet_AK4PFchs"
+            L2Key = "Summer19UL18_RunA_V5_DATA_L2Relative_AK4PFchs"
+            L3Key = "Summer19UL18_RunA_V5_DATA_L3Absolute_AK4PFchs"
+            L2L3Key = "Summer19UL18_RunA_V5_DATA_L2L3Residual_AK4PFchs"
+            scaleTotalKey = None
+            scaleKeyRegrouped11 = None 
+            smearKey = None
+            JERKey = None
+            JERsfKey = None
+        
+    elif era == 2022:
         if is_mc :
             if "pre_EE" in tag:
                 folderKey = "Run3-22CDSep23-Summer22-NanoAODv12/2025-09-23"
@@ -164,7 +198,7 @@ def getJetCorrected(era, tag, is_mc, overwritePt=True) :
                 f"Summer24Prompt24_V1_MC_{label.format(year='2024')}_AK4PFPuppi" for label in jes_systematics_11split
                 ]
             smearKey = "JERSmear"
-            # It appears the most recent 23Bpix files are used in the following cases: 
+            # It appears the 23Bpix keys are used for the following:
             JERKey = "Summer23BPixPrompt23_RunD_JRV1_MC_PtResolution_AK4PFPuppi"
             JERsfKey = "Summer23BPixPrompt23_RunD_JRV1_MC_ScaleFactor_AK4PFPuppi"
  
@@ -185,6 +219,10 @@ def getJetCorrected(era, tag, is_mc, overwritePt=True) :
             JERKey = None
             JERsfKey = None
 
+    else:
+        raise ValueError("getJetCorrected: Era", era, tag, "not supported")
+
+            
     json_JERC = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/%s/jet_jerc.json.gz" % (folderKey)
     json_JERsmear = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/jer_smear.json.gz" # md5sum: 390e4be4be109bb1a2d3a116f2c9386a
 

--- a/NanoAnalysis/python/modules/jetVMAP.py
+++ b/NanoAnalysis/python/modules/jetVMAP.py
@@ -6,27 +6,27 @@ def getJetVetoMap(era, tag) :
 
     if era == 2022:
             if "pre_EE" in tag:
-                folderKey = "2022_Summer22" # md5sum: e35eddf2b2eb072be63c78035cba01b0
+                folderKey = "Run3-22CDSep23-Summer22-NanoAODv12/2025-09-23" # md5sum: e35eddf2b2eb072be63c78035cba01b0
                 corrName = "Summer22_23Sep2023_RunCD_V1"
             else:
-                folderKey = "2022_Summer22EE" # md5sum: ea16a7d736eacd58677dd761172792aa
+                folderKey = "Run3-22EFGSep23-Summer22EE-NanoAODv12/2025-10-07" # md5sum: ea16a7d736eacd58677dd761172792aa
                 corrName = "Summer22EE_23Sep2023_RunEFG_V1"
     
     elif era == 2023:
             if "pre_BPix" in tag:
-                folderKey = "2023_Summer23" # md5sum: 6e5ea1c9e7303dc72485303b1a6565b2
+                folderKey = "Run3-23CSep23-Summer23-NanoAODv12/2025-10-07" # md5sum: 6e5ea1c9e7303dc72485303b1a6565b2
                 corrName = "Summer23Prompt23_RunC_V1"
             else:
-                folderKey = "2023_Summer23BPix" # md5sum: 1f296a697ca06593ad36a7d53b56fa77
+                folderKey = "Run3-23DSep23-Summer23BPix-NanoAODv12/2025-10-07" # md5sum: 1f296a697ca06593ad36a7d53b56fa77
                 corrName = "Summer23BPixPrompt23_RunD_V1"
 
     elif era == 2024:
         # folderKey = "2024_Winter24" # md5sum: 802a8be50fde0fd45d86c98ea446b16b
         # corrName = "Winter24Prompt2024BCDEFGHI_V1"
-        folderKey = "2024_Summer24" # md5sum: 1cf19b46f969dbd31cb07e664dcca3cf
+        folderKey = "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-07-17" # md5sum: 1cf19b46f969dbd31cb07e664dcca3cf
         corrName = "Summer24Prompt24_RunBCDEFGHI_V1"
 
-    json_JVMAP = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/%s/jetvetomaps.json.gz" % (folderKey)
+    json_JVMAP = f"/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/{folderKey}/jetvetomaps.json.gz"
     veto_map_name= "jetvetomap"
     print("***jetJVMAP: era:", era, "tag:", tag, "corrName:", corrName, "json:", json_JVMAP)
 

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -23,13 +23,12 @@ SAMPLENAME = getConf("SAMPLENAME", "test")
 LEPTON_SETUP = getConf("LEPTON_SETUP", 2018)
 DATA_TAG = getConf("DATA_TAG", "" ) # used to distinguish different subperiods/reprocessings.
                                     # Specific values currently recognized (other values->use defaults for era)
-                                    # "UL" (used by muonScaleResProducer_Rochester, getEleBDTCut)
-                                    # "ULAPV", (used by LeptonSFHelper)
-                                    # "pre_EE" (used by LeptonSFHelper, eleScaleResProducer, muonScaleResProducer, puWeightProducer, jetJERC)
+                                    # "UL" (used by muonScaleResProducer_Rochester, getEleBDTCut, jetJERC)
+                                    # "ULAPV", (used by LeptonSFHelper, jetJERC)
+                                    # "pre_EE", "pre_BPix" (used by LeptonSFHelper, eleScaleResProducer, muonScaleResProducer, puWeightProducer, jetJERC, jetVMAP)
                                     # "2022E", "2022F", "2022G" (used by jetJERC)
 NANOVERSION = getConf("NANOVERSION", 12)
-#NANOVERSION = getConf("NANOVERSION", 15)
-if not (LEPTON_SETUP == 2016 or LEPTON_SETUP == 2017 or LEPTON_SETUP == 2018 or LEPTON_SETUP == 2022 or LEPTON_SETUP == 2023 or LEPTON_SETUP == 2024 or LEPTON_SETUP == 2025) :
+if LEPTON_SETUP not in [2016, 2017, 2018, 2022, 2023, 2024, 2025] :
     print("Invalid LEPTON_SETUP", LEPTON_SETUP)
     exit(1)
 IsMC = getConf("IsMC", True)
@@ -216,6 +215,7 @@ elif NANOVERSION >=13 :
     insertBefore(reco_sequence, 'jetFiller', getJetIdProducer(LEPTON_SETUP, DATA_TAG))   
 
 # Add jet corrections for Run 3
+# FIXME: jet corrs for Run2 v15 to be added
 if APPLYJETCORR and LEPTON_SETUP >=2022 :
     from ZZAnalysis.NanoAnalysis.modules.jetJERC import getJetCorrected
     insertBefore(reco_sequence, 'jetFiller', getJetCorrected(LEPTON_SETUP, DATA_TAG, IsMC, overwritePt=True))
@@ -265,11 +265,11 @@ if IsMC:
                                                'passedFiducial',
                                                'Generator_weight',
                                                'puWeight*',
-                                               'ggH_NNLOPS_Weight',
                                                'overallEventWeight',
                                                'Pileup_nTrueInt',
                                                'LHEMela*',
                                                'GenJet*',
+                                               *(['ggH_NNLOPS_Weight'] if APPLY_QCD_GGF_UNCERT else []),
                                                ],
                                       #Stop further processing for events that don't have 4 reco leps
                                       continueFor = postPresel
@@ -327,9 +327,9 @@ branchsel_out = ['drop *',
                  'keep HLT_passZZ*',
                  'keep best*', # best candidate indices
                  'keep Z*', # Z, ZZ, ZLL candidates
-                 'keep MET_pt',
                  #'keep PV*',
                  #'keep Flag*',
+                 *(['keep MET_pt'] if NANOVERSION <=12 else ['keep PFMET_pt']),
                  ]
 
 if IsMC:
@@ -342,10 +342,9 @@ if IsMC:
                           'keep HTXS_*',
                           'keep Pileup*',
                           'keep GenJet_*',
-                          'keep genxsec', 
-                          'keep genbr',
                           #'keep Generator*',
                           #'keep PV*',
+                          *(['keep genxsec','keep genbr'] if (genXS != 1) and (genBR != 1) else [])
                         ])
 
     if ADD_ALLEVENTS : # Gen-level variables that are relevant only for signals

--- a/NanoAnalysis/python/triggerAndSkim.py
+++ b/NanoAnalysis/python/triggerAndSkim.py
@@ -37,6 +37,14 @@ class triggerAndSkim(Module):
 
         ### Trigger requirements
         passTrigger = False
+        if self.era == 2016 :
+            passSingleEle = event.HLT_Ele25_eta2p1_WPTight_Gsf or event.HLT_Ele27_WPTight_Gsf or event.HLT_Ele27_eta2p1_WPLoose_Gsf or event.HLT_Ele32_eta2p1_WPTight_Gsf
+            passSingleMu = event.HLT_IsoMu20 or event.HLT_IsoTkMu20 or event.HLT_IsoMu22 or event.HLT_IsoTkMu22 or event.HLT_IsoMu24 or event.HLT_IsoTkMu24
+            passDiEle = event.HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ or event.HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ or event.HLT_DoubleEle33_CaloIdL_GsfTrkIdVL
+            passDiMu = event.HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ or event.HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ or event.HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL or event.HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL
+            passMuEle = event.HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL or event.HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL or event.HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ or event.HLT_Mu17_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL or event.HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL or event.HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ or event.HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL or event.HLT_Mu8_DiEle12_CaloIdL_TrackIdL or event.HLT_DiMu9_Ele9_CaloIdL_TrackIdL
+            passTriEle = event.HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL
+            passTriMu = event.HLT_TripleMu_12_10_5
         if self.era == 2017 :
             passSingleEle = event.HLT_Ele35_WPTight_Gsf or event.HLT_Ele38_WPTight_Gsf or event.HLT_Ele40_WPTight_Gsf
             passSingleMu = event.HLT_IsoMu27

--- a/NanoAnalysis/python/weightFiller.py
+++ b/NanoAnalysis/python/weightFiller.py
@@ -10,7 +10,7 @@ ROOT.PyConfig.IgnoreCommandLineOptions = True
 
 class weightFiller(Module):
     def __init__(self, XS, APPLY_K_NNLOQCD_ZZGG, APPLY_K_NNLOQCD_ZZQQB, APPLY_K_NNLOEW_ZZQQB, APPLY_QCD_GGF_UNCERT, LEPTON_SETUP):
-        print("***weightFiller: XS:", XS, flush=True)
+        print("***weightFiller: XS:", XS, "K_NNLOQCD_ZZGG:", APPLY_K_NNLOQCD_ZZGG, "K_NNLOQCD_ZZQQB:", APPLY_K_NNLOQCD_ZZQQB, "GGF_NNLO_W:", APPLY_QCD_GGF_UNCERT, flush=True)
         self.writeHistFile = False
         self.XS = XS
         self.APPLY_K_NNLOQCD_ZZGG = APPLY_K_NNLOQCD_ZZGG

--- a/NanoAnalysis/test/runLocal.py
+++ b/NanoAnalysis/test/runLocal.py
@@ -12,16 +12,20 @@ from ZZAnalysis.AnalysisStep.validateCheckout import validateCheckout
 if not validateCheckout() :
     exit(1)
 
-#SampleToRun = "MCsync_2018Rereco" # for mini vs nano sync
-#SampleToRun = "MCsync_2017UL" # for mini vs nano sync
+#SampleToRun = "MCsync_2018UL" # v15 2018UL nano
 #SampleToRun = "Data2022"
 SampleToRun = "MC2022EE"
 #SampleToRun = "MC2023postBPix"
-#SampleToRun = "MELA_Test"
-#SampleToRun = "ggh125_2018UL"
-#SampleToRun = "forNanoDoc" # To prepare variable lists with inspectNanoFile.py
 #SampleToRun = "Data2024"
 #SampleToRun = "MC2024"
+#SampleToRun = "MELA_Test"
+#SampleToRun = "forNanoDoc" # To prepare variable lists with inspectNanoFile.py
+
+### Obsolete Run2 samples
+#SampleToRun = "ggh125_2018UL_v2"
+#SampleToRun = "MCsync_2018Rereco_v7" # for mini vs nano sync
+#SampleToRun = "MCsync_2017UL_v9" # for mini vs nano sync
+
 
 ### Customize processing variables.
 #setConf("runMELA", False)
@@ -82,7 +86,7 @@ elif SampleToRun == "Data2024" :
                          ])
 
 ################################################################################
-elif SampleToRun == "ggh125_2018UL" : ### 2018 UL test sample
+elif SampleToRun == "ggh125_2018UL_v2" : ### 2018 UL test sample
     setConf("SAMPLENAME", "ggH125")
     setConf("XSEC", 48.58*0.0002745)
     setConf("LEPTON_SETUP", 2018)
@@ -94,7 +98,7 @@ elif SampleToRun == "ggh125_2018UL" : ### 2018 UL test sample
         ])
 
 ################################################################################
-elif SampleToRun == "MCsync_2017UL" :
+elif SampleToRun == "MCsync_2017UL_v9" :
     # Custom-reprocessed Rereco nanoAOD file with updated FSR and electron MVA,
     # no packing for genparticle p3; 26000 events
     # corresponding to:/store/mc/RunIISummer20UL17MiniAODv2/GluGluHToZZTo4L_M125_TuneCP5_13TeV_powheg2_JHUGenV7011_pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v2/130000/3E4E8D55-3993-2B43-AF3B-7AB45BBE0BDA.root
@@ -109,7 +113,7 @@ elif SampleToRun == "MCsync_2017UL" :
 
 
 ################################################################################
-elif SampleToRun == "MCsync_2018Rereco" :
+elif SampleToRun == "MCsync_2018Rereco_v7" :
      # Custom-reprocessed Rereco nanoAOD file with updated FSR,
      # corresponding to:/store/mc/RunIIAutumn18NanoAODv7/GluGluHToZZTo4L_M125_13TeV_powheg2_JHUGenV7011_pythia8/NANOAODSIM/Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/260000/BA6D7F40-ED5E-7D4E-AB14-CE8A9C5DE7EC.root
     setConf("APPLYMUCORR", True)
@@ -119,6 +123,19 @@ elif SampleToRun == "MCsync_2018Rereco" :
     setConf("store","")
     setConf("fileNames",["/eos/user/n/namapane/H4lnano/ggH125_fixedFSR.root"])
 
+################################################################################
+elif SampleToRun == "MCsync_2018UL" :
+    # 2018 UL, v15; LSs in json are included in parent /store/mc/RunIISummer20UL18MiniAODv2/GluGluHToZZTo4L_M125_TuneCP5_13TeV_powheg2_JHUGenV7011_pythia8/MINIAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/240000/E6F5DEE7-DAC9-E14E-8362-8A0EFF7B38CD.root
+    setConf("SAMPLENAME", "ggH125")
+    setConf("XSEC", 48.58*0.0002745)
+    setConf("NANOVERSION", 15)
+    setConf("DATA_TAG", "UL") 
+    setConf("LEPTON_SETUP", 2018)
+    setConf("APPLY_QCD_GGF_UNCERT", True) # for ggH
+    setConf("APPLYJETCORR", False) #FIXME
+    setConf("store","root://cms-xrd-global.cern.ch/")
+    setConf("fileNames",["/store/mc/RunIISummer20UL18NanoAODv15/GluGluHToZZTo4L_M125_TuneCP5_13TeV_powheg2_JHUGenV7011_pythia8/NANOAODSIM/150X_mc2018_realistic_v1-v1/130000/501e594d-38c4-4ab1-8a86-ec8b2663173c.root"])
+    json = {"1": [[847,848],[871,873],[874,875],[901,902]]}
 
 ################################################################################
 elif SampleToRun == "MC2022EE" :


### PR DESCRIPTION
First batch of updates to handle Run2UL nanoAODv15 samples.

Still missing:
- complete setup and include jet correction module (to be verified)
- regression vs miniAOD results
- csv files

Also, updated jeyID.py and jetVMAP.py to use the [new versioned repository](https://cms-analysis-corrections.docs.cern.ch/) for json files instead than the deprecated one ([jsonpog-integration](https://gitlab.cern.ch/cms-nanoAOD/jsonpog-integration/)). Correction files are identical.