### PR TITLE
Add associated particles (jets and extra leptons) to the input for MELA

### DIFF
--- a/NanoAnalysis/python/RecoProbFiller.py
+++ b/NanoAnalysis/python/RecoProbFiller.py
@@ -50,8 +50,8 @@ class RecoProbFiller(Module):
             daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[1].pdgId, dressedLepsp4[1].Px(), dressedLepsp4[1].Py(), dressedLepsp4[1].Pz(), dressedLepsp4[1].E()))
             daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[2].pdgId, dressedLepsp4[2].Px(), dressedLepsp4[2].Py(), dressedLepsp4[2].Pz(), dressedLepsp4[2].E()))
             daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[3].pdgId, dressedLepsp4[3].Px(), dressedLepsp4[3].Py(), dressedLepsp4[3].Pz(), dressedLepsp4[3].E()))
-        
-            self.ProbHelper.fillProbs(candsDaughters, candsAssociated, None)
+
+        self.ProbHelper.fillProbs(candsDaughters, candsAssociated, None)
 
         return True
     

--- a/NanoAnalysis/python/RecoProbFiller.py
+++ b/NanoAnalysis/python/RecoProbFiller.py
@@ -36,9 +36,21 @@ class RecoProbFiller(Module):
         cands = Collection(event, 'ZZCand')
         leps = Collection(event, 'Lepton')
         fsrPhotons = Collection(event, "FsrPhoton")
+        jets = Collection(event, 'Jet')
+
+        # Add leading and sub-leadig jets, if present
+        jets_idx = [i for i in (event.JetLeadingIdx, event.JetSubleadingIdx) if i >= 0]
+        jets_MELA = Mela.SimpleParticleCollection_t()
+        for idx in jets_idx:
+            jet = jets[idx]
+            p4 = jet.p4()
+            jets_MELA.add_particle(Mela.SimpleParticle_t(0, p4.Px(), p4.Py(), p4.Pz(), p4.E()))
+
         # Cache the daughters for each candidate
         candsDaughters = [Mela.SimpleParticleCollection_t()]*len(cands)
-        candsAssociated = [None]*len(cands) # FIXME to be added
+        # The jets are the same for every candidate
+        candsAssociated = [copy.deepcopy(jets_MELA)]*len(cands)
+
         for iCand, aCand in enumerate(cands):
             theCandLepIdxs = [aCand.Z1l1Idx, aCand.Z1l2Idx, aCand.Z2l1Idx, aCand.Z2l2Idx]  
             theCandLeps = [leps[i] for i in theCandLepIdxs]

--- a/NanoAnalysis/python/RecoProbFiller.py
+++ b/NanoAnalysis/python/RecoProbFiller.py
@@ -63,6 +63,12 @@ class RecoProbFiller(Module):
             daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[2].pdgId, dressedLepsp4[2].Px(), dressedLepsp4[2].Py(), dressedLepsp4[2].Pz(), dressedLepsp4[2].E()))
             daughters.add_particle(Mela.SimpleParticle_t(theCandLeps[3].pdgId, dressedLepsp4[3].Px(), dressedLepsp4[3].Py(), dressedLepsp4[3].Pz(), dressedLepsp4[3].E()))
 
+            extralep_idx = [i for i in (event.ZZCand_extraLep1Idx[iCand], event.ZZCand_extraLep2Idx[iCand]) if i >= 0]
+            for idx in extralep_idx:
+                lep = leps[idx]
+                p4 = lep.p4()
+                associated.add_particle(Mela.SimpleParticle_t(lep.pdgId, p4.Px(), p4.Py(), p4.Pz(), p4.E()))
+
         self.ProbHelper.fillProbs(candsDaughters, candsAssociated, None)
 
         return True


### PR DESCRIPTION
Only the first two jets and the first two extra leptons, if existing, are added to the collection passed to MELA.
Commit e231969 also makes the call to ProbHelper.fillProbs() run once per event instead of once per ZZ candidate in each event.

Tested with runLocal.py on the sample "MELA_Test"
