### PR TITLE
Fix crash on non-Higgs samples when ADD_ALLEVENTS=True (LHEAngProbFiller)

### DIFF
--- a/NanoAnalysis/python/LHEAngProbFiller.py
+++ b/NanoAnalysis/python/LHEAngProbFiller.py
@@ -100,6 +100,7 @@ class LHEAngProbFiller(Module):
         mothers = Mela.SimpleParticleCollection_t()
         daughters = Mela.SimpleParticleCollection_t()
         associated = Mela.SimpleParticleCollection_t()
+        hMass = -999.
 
 
         ## Only run if mother-daughter associations are available, i.e. nanoAODv15 or newer. 


### PR DESCRIPTION
As the title says, running on samples without an Higgs boson at the LHE level with `setConf("ADD_ALLEVENTS", True)` causes a crash [1].
This can be tested with `runLocal.py` by changing just two lines [2]. The problem is in LHEAngProbFiller, where `analyze()` does not set a value for `hMass` in case there are no LHE particles with pdgId == 25.
The simple fix proposed here is to just add `hMass = -999.` at the beginning of the function. However, I wonder if this is the right solution or is just a way to hide another problem. 

[1]
```
Traceback (most recent call last):
  File "/afs/cern.ch/work/a/amecca/ZZjjRun3/CMSSW_14_1_6/src/ZZAnalysis/NanoAnalysis/test/./runLocal.py", line 277, in <module>
    p.run()
  File "/afs/cern.ch/work/a/amecca/ZZjjRun3/CMSSW_14_1_6/src/PhysicsTools/NanoAODTools/python/postprocessing/framework/postprocessor.py", line 243, in run
    (nall, npass, timeLoop) = eventLoop(
  File "/afs/cern.ch/work/a/amecca/ZZjjRun3/CMSSW_14_1_6/src/PhysicsTools/NanoAODTools/python/postprocessing/framework/eventloop.py", line 80, in eventLoop
    ret = m.analyze(e)
  File "/afs/cern.ch/work/a/amecca/ZZjjRun3/CMSSW_14_1_6/src/ZZAnalysis/NanoAnalysis/python/LHEAngProbFiller.py", line 154, in analyze
    if abs(hMass - daughters.MTotal()) < 0.01 and len(daughters.toList()) == 4:
UnboundLocalError: local variable 'hMass' referenced before assignment
```

[2]
```
diff --git a/NanoAnalysis/test/runLocal.py b/NanoAnalysis/test/runLocal.py
index 9f87a3ac..8af0bb48 100755
--- a/NanoAnalysis/test/runLocal.py
+++ b/NanoAnalysis/test/runLocal.py
@@ -43,7 +43,7 @@ setConf("PROCESS_CR", True)
 setConf("PROCESS_ZL", True)
 setConf("DEBUG", False)
 setConf("SYNCMODE", True) # Force muon resolution correction with fixed +1 sigma smearing
-#setConf("ADD_ALLEVENTS", True) # Add extra tree of gen info for all events
+setConf("ADD_ALLEVENTS", True) # Add extra tree of gen info for all events
 #setConf("FILTER_EVENTS", 'Z') # Store all events which contain a good Z candidate
 #setConf("FILTER_EVENTS", '3L_20_10') # for trigger studies
 #setConf("FILTER_EVENTS", 'NoFilter') # don't skip events with no candidates
@@ -149,7 +149,7 @@ elif SampleToRun == "MC2022EE" :
     setConf("APPLY_QCD_GGF_UNCERT", True) # for ggH
 #   setConf("MUON_ID_BYMVA", True)
     setConf("fileNames",[
-        "/store/mc/Run3Summer22EENanoAODv12/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_postEE_v6>
+        "/store/mc/Run3Summer22EENanoAODv12/ZZZ_TuneCP5_13p6TeV_amcatnlo-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_postEE_v6-v2/2530000/4c3be550-f4d0-4c>
 #        "/store/mc/Run3Summer22EENanoAODv12/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_postEE_v>
         ])
 #    json = {"1": [[1245, 1245],[1306, 1306],[1410, 1410],[1692, 1692],[1903, 1903],[1910, 1910],[1915, 1915],[1927, 1927],[1939, 1939],[1940, 1940],[1944, >
-- 
2.38.1
```