### PR TITLE
Add VBS samples

### DIFF
--- a/NanoAnalysis/test/prod/samplesNano_2022EE_MC.csv
+++ b/NanoAnalysis/test/prod/samplesNano_2022EE_MC.csv
@@ -90,3 +90,8 @@ TTto2L2Nu,,98.0,,,/TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAO
 ###,,,,,,,,,,,Equivalent of ttZJets in Run2
 TTLL_MLL-4to50 ,,0.03949,,,/TTLL_MLL-4to50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,2,PROCESS_CR=True;LEPTON_SETUP=2022,,xsec from XSDB
 TTLL_MLL-50 ,,0.08646,,,/TTLL_MLL-50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,2,PROCESS_CR=True;LEPTON_SETUP=2022,,xsec from XSDB
+
+###,,,,,,,,,,,VBS
+ZZTo4l_2Jets_EW_QCD,,0.02157,,,/ZZto4L-2Jets_EW-QCD_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2022,,#xsec from XSDB
+ZZTo4l_2Jets_EW,,0.001142,,,/ZZto4L-2Jets_EW_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2022,,#xsec from XSDB
+ZZTo4l_2Jets_QCD,,0.02029,,,/ZZto4L-2Jets_QCD_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2022,,#xsec from XSDB

--- a/NanoAnalysis/test/prod/samplesNano_2022_MC.csv
+++ b/NanoAnalysis/test/prod/samplesNano_2022_MC.csv
@@ -89,3 +89,8 @@ TTto2L2Nu,,98.0,,,/TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv
 ###,,,,,,,,,,,Equivalent of ttZJets in Run2
 TTLL_MLL-4to50,,0.03949,,,/TTLL_MLL-4to50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,2,PROCESS_CR=True;LEPTON_SETUP=2022;DATA_TAG=pre_EE,, #xsec from XSDB
 TTLL_MLL-50,,0.08646,,,/TTLL_MLL-50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,2,PROCESS_CR=True;LEPTON_SETUP=2022;DATA_TAG=pre_EE,, #xsec from XSDB
+
+###,,,,,,,,,,,VBS
+ZZTo4l_2Jets_EW_QCD,,0.02157,,,/ZZto4L-2Jets_EW-QCD_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2022;DATA_TAG=pre_EE,,#xsec from XSDB
+ZZTo4l_2Jets_EW,,0.001142,,,/ZZto4L-2Jets_EW_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2022;DATA_TAG=pre_EE,,#xsec from XSDB
+ZZTo4l_2Jets_QCD,,0.02029,,,/ZZto4L-2Jets_QCD_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2022;DATA_TAG=pre_EE,,#xsec from XSDB

--- a/NanoAnalysis/test/prod/samplesNano_2023postBPix_MC.csv
+++ b/NanoAnalysis/test/prod/samplesNano_2023postBPix_MC.csv
@@ -78,3 +78,8 @@ TTto2L2Nu                       ,,98.0,,,/TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythi
 ###,,,,,,,,,,,Equivalent of ttZJets in Run2
 TTLL_MLL-4to50                    ,,0.03949,,,/TTLL_MLL-4to50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v3/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,2,PROCESS_CR=True;PROCESS_ZL=True;FILTER_EVENTS=Z;LEPTON_SETUP=2023;DATA_TAG=post_BPix,, #xsec obtained from xsdb
 TTLL_MLL-50                       ,,0.08646,,,/TTLL_MLL-50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v3/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,2,PROCESS_CR=True;PROCESS_ZL=True;FILTER_EVENTS=Z;LEPTON_SETUP=2023;DATA_TAG=post_BPix,, #xsec obtained from xsdb
+
+###,,,,,,,,,,,VBS
+ZZTo4l_2Jets_EW_QCD,,0.02157,,,/ZZto4L-2Jets_EW-QCD_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;APPLY_K_NNLOQCD_ZZQQB=True;APPLY_K_NLOEW_ZZQQB=True;LEPTON_SETUP=2023;DATA_TAG=post_BPix,,#xsec from xsdb
+ZZTo4l_2Jets_EW,,0.001142,,,/ZZto4L-2Jets_EW_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;APPLY_K_NNLOQCD_ZZQQB=True;APPLY_K_NLOEW_ZZQQB=True;LEPTON_SETUP=2023;DATA_TAG=post_BPix,,#xsec from xsdb
+ZZTo4l_2Jets_QCD,,0.02029,,,/ZZto4L-2Jets_QCD_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;APPLY_K_NNLOQCD_ZZQQB=True;APPLY_K_NLOEW_ZZQQB=True;LEPTON_SETUP=2023;DATA_TAG=post_BPix,,#xsec from xsdb

--- a/NanoAnalysis/test/prod/samplesNano_2023preBPix_MC.csv
+++ b/NanoAnalysis/test/prod/samplesNano_2023preBPix_MC.csv
@@ -78,3 +78,8 @@ TTto2L2Nu                   ,,98.0,,,/TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/R
 ###,,,,,,,,,,,Equivalent of ttZJets in Run2
 TTLL_MLL-4to50                         ,,0.03949,,,/TTLL_MLL-4to50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,2,PROCESS_CR=True;LEPTON_SETUP=2023;DATA_TAG=pre_BPix,, #xsec obtained from xsdb
 TTLL_MLL-50                            ,,0.08646,,,/TTLL_MLL-50_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,2,PROCESS_CR=True;LEPTON_SETUP=2023;DATA_TAG=pre_BPix,, #xsec obtained from xsdb
+
+###,,,,,,,,,,,VBS
+ZZTo4l_2Jets_EW_QCD,,0.02157,,,/ZZto4L-2Jets_EW-QCD_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2023;DATA_TAG=pre_BPix,,#xsec from xsdb
+ZZTo4l_2Jets_EW,,0.001142,,,/ZZto4L-2Jets_EW_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2023;DATA_TAG=pre_BPix,,#xsec from xsdb
+ZZTo4l_2Jets_QCD,,0.02029,,,/ZZto4L-2Jets_QCD_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2023;DATA_TAG=pre_BPix,,#xsec from xsdb

--- a/NanoAnalysis/test/prod/samplesNano_2024_MC.csv
+++ b/NanoAnalysis/test/prod/samplesNano_2024_MC.csv
@@ -82,3 +82,8 @@ TTto2L2Nu                       ,,98.0,,,/TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythi
 # ttZJets Equivalent from run 2
 TTLL_MLL-4to50                            ,,0.03949,,,/TTLL_Bin-MLL-4to50_TuneCP5_13p6TeV_amcatnlo-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,2,PROCESS_CR=True;LEPTON_SETUP=2024,, #xsec obtained from xsdb
 TTLL_MLL-50                            ,,0.08646,,,/TTLL_Bin-MLL-50_TuneCP5_13p6TeV_amcatnlo-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,2,PROCESS_CR=True;LEPTON_SETUP=2024,, #xsec obtained from xsdb 
+
+###,,,,,,,,,,,VBS
+ZZTo4l_2Jets_EW_QCD,,0.02158,,,/ZZJJto4L-EWK-QCD_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAOD-140X_mcRun3_2024_realistic_v26-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2024,,#xsec from xsdb
+ZZTo4l_2Jets_EW,,0.001144,,,/ZZJJto4L-EWK_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2024,,#xsec from xsdb
+ZZTo4l_2Jets_QCD,,0.02029,,,/ZZJJto4L-EWK_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2024,,#xsec from xsdb


### PR DESCRIPTION
This add the samples used by VBS to the common CSV files. Note that the primary dataset is different between 2022/23 (`ZZto4L-2Jets_...`) and 2024 (`ZZJJto4L-...`). The cross sections are taken from XSDB.
Not sure if the settings `APPLY_K_...` need to be used.