### PR TITLE
Add MELA probabilities for VBS

### DIFF
--- a/NanoAnalysis/test/prod/pyFragments/VBS_probs.py
+++ b/NanoAnalysis/test/prod/pyFragments/VBS_probs.py
@@ -1,0 +1,35 @@
+from ZZAnalysis.NanoAnalysis.tools import setConf
+
+__common = {
+    "MatrixElement": "MCFM",
+    "Process": "bkgZZ",
+    "Prod": True,
+    "Dec": True,
+    "Couplings": {},
+    "context": "Reco",
+    "computeprop": False
+}
+
+__probs = [
+    {
+        **__common,
+        "Production": "JJVBF",
+        "Name": "JJVBF_BKG_MCFM_JECNominal",
+    },
+    {
+        **__common,
+        "Name": "JJQCD_BKG_MCFM_JECNominal",
+        "Production": "JJQCD",
+    },
+    {
+        **__common,
+        "Name": "JJEWQCD_BKG_MCFM_JECNominal",
+        "Production": "JJEWQCD",
+    },
+]
+
+for __prob in __probs:
+    setConf("probabilities", __prob, append=True)
+
+# Do not pollute the global namespace if someone does "import *" of this module
+del __common, __probs, __prob

--- a/NanoAnalysis/test/prod/samplesNano_2024_MC.csv
+++ b/NanoAnalysis/test/prod/samplesNano_2024_MC.csv
@@ -84,6 +84,6 @@ TTLL_MLL-4to50                            ,,0.03949,,,/TTLL_Bin-MLL-4to50_TuneCP
 TTLL_MLL-50                            ,,0.08646,,,/TTLL_Bin-MLL-50_TuneCP5_13p6TeV_amcatnlo-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,2,PROCESS_CR=True;LEPTON_SETUP=2024,, #xsec obtained from xsdb 
 
 ###,,,,,,,,,,,VBS
-ZZTo4l_2Jets_EW_QCD,,0.02158,,,/ZZJJto4L-EWK-QCD_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAOD-140X_mcRun3_2024_realistic_v26-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2024,,#xsec from xsdb
+ZZTo4l_2Jets_EW_QCD,,0.02158,,,/ZZJJto4L-EWK-QCD_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2024,,#xsec from xsdb
 ZZTo4l_2Jets_EW,,0.001144,,,/ZZJJto4L-EWK_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2024,,#xsec from xsdb
 ZZTo4l_2Jets_QCD,,0.02029,,,/ZZJJto4L-EWK_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM,dbs,root://cms-xrd-global.cern.ch/,3,PROCESS_CR=True;LEPTON_SETUP=2024,,#xsec from xsdb

--- a/NanoAnalysis/test/runLocal.py
+++ b/NanoAnalysis/test/runLocal.py
@@ -19,6 +19,7 @@ SampleToRun = "MC2022EE"
 #SampleToRun = "Data2024"
 #SampleToRun = "MC2024"
 #SampleToRun = "MELA_Test"
+#SampleToRun = "MELA_VBS_ZZjj-EWK"
 #SampleToRun = "forNanoDoc" # To prepare variable lists with inspectNanoFile.py
 
 ### Obsolete Run2 samples
@@ -229,6 +230,29 @@ elif SampleToRun == "MELA_Test" :
         "/store/mc/RunIII2024Summer24NanoAODv15/GluGluH-Hto2Zto4L_Par-M-125_TuneCP5_13p6TeV_powheg-jhugen-pythia8/NANOAODSIM/150X_mcRun3_2024_realistic_v2-v2/110000/a9e03ff9-2146-4aff-bd26-69abcb98359f.root" # 10000 evts
     ])
     
+
+elif SampleToRun.startswith("MELA_VBS"):
+    setConf("LEPTON_SETUP", 2024)
+    setConf("IsMC", True)
+    setConf("NANOVERSION", 15)
+    setConf("store", "root://cms-xrd-global.cern.ch/")
+
+    setConf("probabilities", [])
+    import prod.pyFragments.VBS_probs
+
+    if(SampleToRun == "MELA_VBS_ZZjj-EWK"):
+        setConf("SAMPLENAME", "ZZjj-EWK")
+        setConf("fileNames", [
+            "/store/mc/RunIII2024Summer24NanoAODv15/ZZJJto4L-EWK_TuneCP5_13p6TeV_madgraph-pythia8/NANOAODSIM/150X_mcRun3_2024_realistic_v2-v2/110000/3ef8745a-d896-4db5-98cc-a6992fd2636d.root"
+        ])
+    elif(SampleToRun == "MELA_VBS_ZZjj-QCD"):
+        setConf("SAMPLENAME", "ZZjj-QCD")
+        setConf("fileNames", [
+            "/store/mc/RunIII2024Summer24NanoAODv15/ZZJJto4L-QCD_TuneCP5_13p6TeV_madgraph-pythia8/NANOAODSIM/150X_mcRun3_2024_realistic_v2-v2/120000/a92b9c18-7301-41a9-b932-00fae13831de.root"
+        ])
+    else:
+        raise ValueError("unknown sample %s" %(sample))
+
 
 ################################################################################
 ### Tweak postprocessor parameters as necessary


### PR DESCRIPTION
This adds the VBS MELA scores as a pyFragment, which calls `setConf()` upon import. It also adds a (commented) test sample in `runLocal.py` which demonstrates how to add these probabilities in production. This can also be accomplished by adding VBS_probs.py into the pyFragments column of the csv for each sample. If the runtime and space costs are not excessive, in the future we may also include them by default. 
There is also a small fix: a 2024 sample was not using Nano v15.