### PR TITLE
Jets corrections

### DIFF
--- a/NanoAnalysis/python/jetFiller.py
+++ b/NanoAnalysis/python/jetFiller.py
@@ -13,10 +13,11 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collect
 from PhysicsTools.HeppyCore.utils.deltar import deltaR
 
 class jetFiller(Module):
-    def __init__(self):
+    def __init__(self, year):
         print("***jetFiller", flush=True)
         self.dRMin = 0.4 # dR between lepton (or FSR) and jet to assume overlap
         self.EFthreshold = 0.5 # threshold of leptons pt over jet pt to veto the jet
+        self.year = year
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
@@ -66,10 +67,17 @@ class jetFiller(Module):
                 # Consider only jets passing  tight ID and tightLepVeto ID, cf. https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID13p6TeV#nanoAOD_Flags
                 # FIXME: To be checked/updated for Run2 
                 if jet.jetId == 6 :
-                    # Eta-dependent PT cut. NOTE: The 50 GeV pT cut in the forward eta region (2.5 < |eta| < 3.0)
-                    # was introduced following JME recommendations
-                    # Ref: https://gitlab.cern.ch/cms-jetmet/coordination/coordination/-/issues/113
-                    if jet.pt > 50 or (jet.pt > 30 and not (2.5 < abs(jet.eta) < 3.0)) :
+                    #Summary of applied pT cuts following JME recommendations:
+                    #Jets with abs(eta) < 2.5 -> pt_cut = 30
+                    #Jets with 2.5 <= abs(eta) < 3.0 -> pt_cut = 50 , Ref: https://gitlab.cern.ch/cms-jetmet/coordination/coordination/-/issues/113
+                    #Jets with abs(eta) >= 3.0 in 2022/2023 -> pt_cut = 50
+                    #Jets with abs(eta) >= 3.0 in other years -> pt_cut = 30
+                    #See slide 14: https://indico.cern.ch/event/1615783/contributions/6811120/attachments/3186812/5672346/20251204_JetMET_PerformanceRun3.pdf
+                    pt_cut = 30
+                    if 2.5 <= abs(jet.eta) < 3.0 or (abs(jet.eta) >= 3.0 and self.year in [2022, 2023]):
+                        pt_cut = 50
+
+                    if jet.pt > pt_cut:
                         nCleanedJetsPt30 += 1
                         #FIXME: add jesUp, jesDn
                 

--- a/NanoAnalysis/python/modules/jetJERC.py
+++ b/NanoAnalysis/python/modules/jetJERC.py
@@ -237,4 +237,4 @@ def getJetCorrected(era, tag, is_mc, overwritePt=True) :
 
     print("***jetJERC: era:", era, "tag:", tag, "is MC:", is_mc, "overwritePt:", overwritePt, "phiDependent:", usePhiDependentJEC, "runDependent:", useRunDependentJEC, "JesSplittingScheme11:", useJesSplittingScheme11,"json_JERC:", json_JERC, "json_JERsmear:", json_JERsmear)
     
-    return jetJERC(json_JERC, json_JERsmear, L1Key, L2Key, L3Key, L2L3Key, scaleKey, smearKey, JERKey, JERsfKey, overwritePt, usePhiDependentJEC, useRunDependentJEC)
+    return jetJERC(era, json_JERC, json_JERsmear, L1Key, L2Key, L3Key, L2L3Key, scaleKey, smearKey, JERKey, JERsfKey, overwritePt, usePhiDependentJEC, useRunDependentJEC)

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -193,7 +193,7 @@ reco_sequence = [lepFiller(cuts, LEPTON_SETUP, MUON_ID_BYMVA), # FSR and FSR-cor
                           filter=FILTER_EVENTS,
                           candsToStore=CANDSTOSTORE,
                           debug=DEBUG), # Build ZZ candidates; choose best candidate; filter events with candidates
-                 jetFiller(), # Jets cleaning with leptons
+                 jetFiller(year=LEPTON_SETUP), # Jets cleaning with leptons
                  ZZExtraFiller(mela, IsMC, LEPTON_SETUP, DATA_TAG, PROCESS_CR), # Additional variables to selected candidates
                  ]
 

--- a/checkout_13X.csh
+++ b/checkout_13X.csh
@@ -82,7 +82,7 @@ fi
    
 #get nanoAODTools modules
 git clone https://github.com/cms-cat/nanoAOD-tools-modules.git PhysicsTools/NATModules
-(cd PhysicsTools/NATModules; git checkout -b from-0c78b79 0c78b79)
+(cd PhysicsTools/NATModules; git checkout -b from-19289f6 19289f6)
 
 
 #CommonLHETools requires the MELA env to be set for compilation


### PR DESCRIPTION
This PR implements the JME recommendations for improving Data/MC agreement in Run 3:
- Added a pT > 50 GeV requirement for **HF jets (3 < |η| < 5) in 2022 and 2023**, as recommended by JME ([see slide 14 from JME presentation](https://indico.cern.ch/event/1615783/contributions/6811120/attachments/3186812/5672346/20251204_JetMET_PerformanceRun3.pdf)).
- Updated JetJERC.py to pass the `era` to `JetJERC`, enabling the implementation of the JME recommendation for **2024 Data/MC agreement in 2.0 < |η| < 2.5**.
In this region, the L2L3Residual correction is frozen at pT = 30 GeV for jets with pT < 30 GeV. See the corresponding PR in NATModules: https://github.com/cms-cat/nanoAOD-tools-modules/pull/27