### PR TITLE
Tools to shift pTs to syst variations for syst studies

### DIFF
--- a/AnalysisStep/src/classes.h
+++ b/AnalysisStep/src/classes.h
@@ -12,3 +12,4 @@ pat::UserHolder<std::vector<edm::Ptr<pat::PFParticle> > > dummy2;
 
 #include <JHUGenMELA/MELA/interface/Mela.h>
 #include <JHUGenMELA/MELA/interface/TUtil.hh>
+#include <ZZAnalysis/AnalysisStep/interface/Category.h>

--- a/AnalysisStep/src/classes_def.xml
+++ b/AnalysisStep/src/classes_def.xml
@@ -8,4 +8,5 @@
   <class name="TUtil"/>
   <class name="WeightCalculatorFromHistogram"/>
   <class name="Dataset"/>
+  <function name="categoryMor18"/>
 </lcgdict>

--- a/NanoAnalysis/python/ZZCategorization.py
+++ b/NanoAnalysis/python/ZZCategorization.py
@@ -1,0 +1,68 @@
+'''
+Add categorization to ZZCand and ZLLCand collections.
+This is currently for validation/x-checks, as the actual categorization
+for physics results is normally defined in the statistical analysis step.
+'''
+
+from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
+
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+class ZZCategorization(Module):
+    def __init__(self, processCR=False):
+        self.processCR = processCR
+        print("***ZZCategorization", flush=True)
+        fake=ROOT.KFactors.kfactor_qqZZ_qcd_M # trigger loading of library, so that functions become available
+
+        
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        self.out = wrappedOutputTree
+        self.book("ZZCand")
+        if self.processCR :
+            self.book("ZLLCand")
+
+    def analyze(self, event) :
+        jets = Collection(event, "Jet")
+        nBTag = sum(1 for jet in jets if (jet.jetId == 6 and jet.ZZMask == False and jet.btagDeepFlavB>0.19 and jet.pt>30.)) # FIXME: handle the different pT cut at large eta - best way would be to add a new flag in jetFiller
+        self.fill('ZZCand', event, nBTag)
+        if self.processCR :
+            self.fill('ZLLCand', event, nBTag)
+        return True
+
+    def book(self, collName) :
+        theLenVar="n"+collName
+        self.out.branch(collName+"_categoryMor18", "S", lenVar=theLenVar, title="Categorization")
+
+    def fill(self, collName, event, nBTag) :
+        cands = Collection(event, collName)
+        cats = [-1]*len(cands)
+
+        dir=ROOT.gDirectory.GetDirectory("") #cache dir, since categoryMor18 internally changes directory
+        for iC, aC in enumerate(cands):            
+            cats[iC] = ROOT.categoryMor18(aC.nExtraLep,
+                                          aC.nExtraZ,
+                                          event.nCleanedJetsPt30,
+                                          nBTag,
+                                          ROOT.nullptr, # jetQGLikelihood, unused if useQGTagging==False
+			                  aC.P_JJQCD_SIG_ghg2_1_JHUGen_JECNominal,
+			                  aC.P_JQCD_SIG_ghg2_1_JHUGen_JECNominal,
+			                  aC.P_JJVBF_SIG_ghv1_1_JHUGen_JECNominal,
+			                  aC.P_JVBF_SIG_ghv1_1_JHUGen_JECNominal,
+			                  aC.P_JVBF_SIG_ghv1_1_JHUGen_JECNominal_aux, #pAux_JVBF_SIG_ghv1_1_JHUGen_JECNominal,
+			                  aC.P_HadWH_SIG_ghw1_1_JHUGen_JECNominal,
+			                  aC.P_HadZH_SIG_ghz1_1_JHUGen_JECNominal,
+				          aC.P_HadWH_SIG_ghw1_1_JHUGen_JECNominal_mavjj, #P_HadWH_mavjj_JECNominal,
+				          aC.P_HadWH_SIG_ghw1_1_JHUGen_JECNominal_mavjj_true, #P_HadWH_mavjj_true_JECNominal,
+				          aC.P_HadZH_SIG_ghz1_1_JHUGen_JECNominal_mavjj, #P_HadZH_mavjj_JECNominal,
+				          aC.P_HadZH_SIG_ghz1_1_JHUGen_JECNominal_mavjj_true, #P_HadZH_mavjj_true_JECNominal,
+			                  ROOT.nullptr, # jetPhi, unused if useQGTagging==False
+			                  aC.mass,
+			                  0., # PFMET, unused if useVHMETTagged == False
+                                          False, # useVHMETTagged
+                                          False  # useQGTagging
+                                          )
+         
+        dir.cd()
+        self.out.fillBranch(collName+"_categoryMor18", cats)

--- a/NanoAnalysis/python/lepScaleShifter.py
+++ b/NanoAnalysis/python/lepScaleShifter.py
@@ -1,0 +1,69 @@
+'''
+Replace pT of leptons with up/down scale/smearing syst variations. 
+This is intended for specific studies of systematics and not for general usage.
+'''
+from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
+
+class lepScaleShifter(Module):
+    def __init__(self, id, var):
+        '''
+        replace pT of leptons with abs(pdgId)==<id> with the one of syst variation <var>.
+        id == 0 -> passthrough (module does nothing)
+        '''
+        print(f"***lepScaleShifter: id: {id}, var: {var}") 
+        if id not in [0, 11, 13] :
+            raise ValueError(f"lepScaleShifter: invalid id {id}")
+        modes = {"scaleUp" : 0, "scaleDn" : 1, "smearUp": 2, "smearDn": 3}
+        if id !=0 :
+            try : 
+                self.mode = modes[var]
+            except :
+                raise ValueError(f"lepScaleShifter: invalid var {var}")
+        self.id = id
+        self.var = var
+
+    
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        self.out = wrappedOutputTree
+
+        if self.id == 0 :
+            return
+        elif self.id == 11:
+            self.out.branch("Electron_pt", "F", lenVar="nElectron", title=f"pT shifted, {self.var}")
+            self.out.branch("Electron_corrected_pt", "F", lenVar="nElectron", title=f"pT (central correction)")
+        else :
+            self.out.branch("Muon_pt", "F", lenVar="nMuon", title=f"pT shifted, {self.var}")
+            self.out.branch("Muon_corrected_pt", "F", lenVar="nMuon", title=f"pT (central correction")
+            
+
+    def analyze(self, event):
+        if self.id == 0 :
+            return True
+
+        elif self.id == 11:
+            if event.nElectron == 0 : return True
+            self.out.fillBranch("Electron_corrected_pt", event.Electron_pt)
+            if self.mode == 0 :
+                pts = event.Electron_scaleUp_pt
+            elif self.mode == 1 :
+                pts = event.Electron_scaleDn_pt
+            elif self.mode == 2 :
+                pts = event.Electron_smearUp_pt
+            elif self.mode == 3 :
+                pts = event.Electron_smearDn_pt
+            self.out.fillBranch("Electron_pt", pts)
+        else :
+            if event.nMuon == 0 : return True
+            self.out.fillBranch("Muon_corrected_pt", event.Muon_pt)
+            if self.mode == 0 :
+                pts = event.Muon_scaleUp_pt
+            elif self.mode == 1 :
+                pts = event.Muon_scaleDn_pt
+            elif self.mode == 2 :
+                pts = event.Muon_smearUp_pt
+            elif self.mode == 3 :
+                pts = event.Muon_smearDn_pt
+            self.out.fillBranch("Muon_pt", pts)
+
+        return True

--- a/NanoAnalysis/test/prod/pyFragments/STXS_probs.py
+++ b/NanoAnalysis/test/prod/pyFragments/STXS_probs.py
@@ -107,3 +107,10 @@ setConf("probabilities", {
     "computeprop": False,
     "useconstant": True # This argument affects the normalization, and should generally be set to true for reconstructed events, false forgenerator level events. [from https://spin.pha.jhu.edu/Manual.pdf]
     }, append=True)
+
+
+# Add categoryMor18, as a reference
+from ZZAnalysis.NanoAnalysis.ZZCategorization import *
+def customizeForCategorization_(p) :
+    p.modules.extend([ZZCategorization(False)])
+setConf("customizations", customizeForCategorization_, append=True) 

--- a/NanoAnalysis/test/prod/pyFragments/shiftLepScale.py
+++ b/NanoAnalysis/test/prod/pyFragments/shiftLepScale.py
@@ -1,0 +1,8 @@
+from ZZAnalysis.NanoAnalysis.tools import setConf, getConf, insertBefore
+from ZZAnalysis.NanoAnalysis.lepScaleShifter import *
+
+# Note: scaleShiftId and scaleShiftVar should be defined externally; by default, this module does not apply any shift.
+def customizeForScaleShift_(p) :
+    insertBefore(p.modules, 'lepFiller', lepScaleShifter(getConf("scaleShiftId", 0),getConf("scaleShiftVar", None)))
+
+setConf("customizations", customizeForScaleShift_, append=True) 


### PR DESCRIPTION
- Add a module ([lepScaleShifter.py](https://github.com/CJLST/ZZAnalysis/compare/Run3...namapane:ZZAnalysis:Run3?expand=1#diff-5d72f85062be35341093089d1ed6ea8617b9eacce9f5812126245440f8f2933c)) to shift lepton pTs to the scale/smearing up/down variation before selection is performed. This is intended to be used to determine the impact of approximations like, in particular, shifting the pTs of leptons of selected candidates a posteriori.
- Add **moriond18 categorization**, useful to test the effect of the above. Variable `ZZCand_categoryMor18` is added automatically with fragment `STXS_prob.py`.
This is useful only for development and tests, it's not fully validated for physics. Note in particular that the selection of b-tagging jets is not fully in sync with the normal jet selection (e.g. increased pT threshold at large eta). 

Further developments to ease the evaluation of systematics in the statistical analysis will come in a further PR.
