### PR TITLE
A few updates

### DIFF
--- a/NanoAnalysis/python/jetFiller.py
+++ b/NanoAnalysis/python/jetFiller.py
@@ -21,18 +21,19 @@ class jetFiller(Module):
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
         self.out = wrappedOutputTree
         self.out.branch("Jet_ZZMask", "O", lenVar="nJet", title="jet is vetoed by selected leptons or FSR photons")
-        self.out.branch("Jet_ZZLepEF", "F", lenVar="nJet", title="Fraction of jet pt carried by the vetoing leptons or FSR photons", limitedPrecision=6),
+        self.out.branch("Jet_ZZLepEF", "F", lenVar="nJet", title="Fraction of jet pt carried by the vetoing leptons or FSR photons", limitedPrecision=6)
+        self.out.branch("Jet_ptThreshold", "F", lenVar="nJet", title="pT threshold applied to the jet for counting nCleanedJetsPt30, etc.")
         self.out.branch("JetLeadingIdx", "S", title="index of leading jet after cleaning")
         self.out.branch("JetSubleadingIdx", "S", title="index of subleading jet after cleaning")
         self.out.branch("nCleanedJetsPt30", "B", title="number of cleaned jets above 30 GeV")
-        self.out.branch("nCleanedJetsPt30_jesUp", "B", title="number of cleaned jets, up JES variation")
-        self.out.branch("nCleanedJetsPt30_jesDn", "B", title="number of cleaned jets, down JES variation")
+        # self.out.branch("nCleanedJetsPt30_jesUp", "B", title="number of cleaned jets, up JES variation")
+        # self.out.branch("nCleanedJetsPt30_jesDn", "B", title="number of cleaned jets, down JES variation")
         self.out.branch("nCleanedJetsPt30BTagged", "B", title="number of cleaned jets above 30 GeV passing the b-tagging requirement")
         self.out.branch("nCleanedJetsPt30BTagged_bTagSF", "B", title="number of cleaned jets above 30 GeV passing the b-tagging requirement with SF applied")
-        self.out.branch("nCleanedJetsPt30BTagged_bTagSFUp_correlated", "B", title="number of cleaned jets above 30 GeV passing the b-tagging requirement with SF up variation applied (variation correlated across years)")
-        self.out.branch("nCleanedJetsPt30BTagged_bTagSFUp_uncorrelated", "B", title="number of cleaned jets above 30 GeV passing the b-tagging requirement with SF up variation applied (variation uncorrelated across years)")
-        self.out.branch("nCleanedJetsPt30BTagged_bTagSFDn_correlated", "B", title="number of cleaned jets above 30 GeV passing the b-tagging requirement with SF down variation applied (variation correlated across years)")
-        self.out.branch("nCleanedJetsPt30BTagged_bTagSFDn_uncorrelated", "B", title="number of cleaned jets above 30 GeV passing the b-tagging requirement with SF down variation applied (variation uncorrelated across years)")
+        # self.out.branch("nCleanedJetsPt30BTagged_bTagSFUp_correlated", "B", title="number of cleaned jets above 30 GeV passing the b-tagging requirement with SF up variation applied (variation correlated across years)")
+        # self.out.branch("nCleanedJetsPt30BTagged_bTagSFUp_uncorrelated", "B", title="number of cleaned jets above 30 GeV passing the b-tagging requirement with SF up variation applied (variation uncorrelated across years)")
+        # self.out.branch("nCleanedJetsPt30BTagged_bTagSFDn_correlated", "B", title="number of cleaned jets above 30 GeV passing the b-tagging requirement with SF down variation applied (variation correlated across years)")
+        # self.out.branch("nCleanedJetsPt30BTagged_bTagSFDn_uncorrelated", "B", title="number of cleaned jets above 30 GeV passing the b-tagging requirement with SF down variation applied (variation uncorrelated across years)")
 
     def getJetAttr(self, jet, name, default=False):
         try:
@@ -53,23 +54,27 @@ class jetFiller(Module):
         ## Jet-lepton cleaning with best candidate's leptons and FSR..
         mask = [False]*event.nJet
         jet_lepPtF = [0.]*event.nJet
+        jet_ptThreshold = [30.]*event.nJet
         leadingJetIdx = -1
         subleadingJetIdx =-1
         leadingJetPt = 0.
         subleadingJetPt = 0.
         nCleanedJetsPt30 = 0
-        nCleanedJetsPt30_jesDn = 0
-        nCleanedJetsPt30_jesUp = 0
+        # nCleanedJetsPt30_jesDn = 0
+        # nCleanedJetsPt30_jesUp = 0
         nCleanedJetsPt30BTagged = 0
         nCleanedJetsPt30BTagged_bTagSF = 0
-        nCleanedJetsPt30BTagged_bTagSFUp_correlated = 0
-        nCleanedJetsPt30BTagged_bTagSFUp_uncorrelated = 0
-        nCleanedJetsPt30BTagged_bTagSFDn_correlated = 0
-        nCleanedJetsPt30BTagged_bTagSFDn_uncorrelated = 0
+        # nCleanedJetsPt30BTagged_bTagSFUp_correlated = 0
+        # nCleanedJetsPt30BTagged_bTagSFUp_uncorrelated = 0
+        # nCleanedJetsPt30BTagged_bTagSFDn_correlated = 0
+        # nCleanedJetsPt30BTagged_bTagSFDn_uncorrelated = 0
 
         # According to the analysis recipe at https://twiki.cern.ch/twiki/bin/viewauth/CMS/HiggsZZ4lRunIILegacy#Jets, "[jets] must be cleaned with a DeltaR>0.4 cut wrt all tight leptons in the event passing the SIP and isolation cut computed after FSR correction, as well as with all FSR collected photons attached to these leptons."
         # Note: the current implementation on miniAODs (https://github.com/CJLST/ZZAnalysis/blob/Run2UL_22_nano/AnalysisStep/plugins/JetsWithLeptonsRemover.cc) probably does something different than this. To be reviewed.
         for ij, jet in enumerate(jets) :
+            if 2.5 <= abs(jet.eta) < 3.0 or (abs(jet.eta) >= 3.0 and self.year in [2022, 2023]):
+                jet_ptThreshold[ij] = 50.
+
             for lep in leps :
                 if not lep.ZZFullSel : continue
                 if deltaR(lep.eta, lep.phi, jet.eta, jet.phi) < self.dRMin :
@@ -91,32 +96,29 @@ class jetFiller(Module):
                     #Jets with abs(eta) >= 3.0 in 2022/2023 -> pt_cut = 50
                     #Jets with abs(eta) >= 3.0 in other years -> pt_cut = 30
                     #See slide 14: https://indico.cern.ch/event/1615783/contributions/6811120/attachments/3186812/5672346/20251204_JetMET_PerformanceRun3.pdf
-                    pt_cut = 30
-                    if 2.5 <= abs(jet.eta) < 3.0 or (abs(jet.eta) >= 3.0 and self.year in [2022, 2023]):
-                        pt_cut = 50
 
-                    if jet.pt > pt_cut:
+                    if jet.pt > jet_ptThreshold[ij]:
                         nCleanedJetsPt30 += 1
                         #FIXME: add jesUp, jesDn
                         isBtagged = self.getJetAttr(jet, "isBtagged", False)
                         isBtaggedSF = self.getJetAttr(jet, "isBtaggedwithSF", isBtagged)
-                        isBtaggedSFUp_correlated = self.getJetAttr(jet, "isBtaggedwithSF_up_correlated", isBtaggedSF)
-                        isBtaggedSFUp_uncorrelated = self.getJetAttr(jet, "isBtaggedwithSF_up_uncorrelated", isBtaggedSF)
-                        isBtaggedSFDn_correlated = self.getJetAttr(jet, "isBtaggedwithSF_down_correlated", isBtaggedSF)
-                        isBtaggedSFDn_uncorrelated = self.getJetAttr(jet, "isBtaggedwithSF_down_uncorrelated", isBtaggedSF)
+                        # isBtaggedSFUp_correlated = self.getJetAttr(jet, "isBtaggedwithSF_up_correlated", isBtaggedSF)
+                        # isBtaggedSFUp_uncorrelated = self.getJetAttr(jet, "isBtaggedwithSF_up_uncorrelated", isBtaggedSF)
+                        # isBtaggedSFDn_correlated = self.getJetAttr(jet, "isBtaggedwithSF_down_correlated", isBtaggedSF)
+                        # isBtaggedSFDn_uncorrelated = self.getJetAttr(jet, "isBtaggedwithSF_down_uncorrelated", isBtaggedSF)
 
                         if isBtagged:
                             nCleanedJetsPt30BTagged += 1
                         if isBtaggedSF:
                             nCleanedJetsPt30BTagged_bTagSF += 1
-                        if isBtaggedSFUp_correlated:
-                            nCleanedJetsPt30BTagged_bTagSFUp_correlated += 1
-                        if isBtaggedSFUp_uncorrelated:
-                            nCleanedJetsPt30BTagged_bTagSFUp_uncorrelated += 1
-                        if isBtaggedSFDn_correlated:
-                            nCleanedJetsPt30BTagged_bTagSFDn_correlated += 1
-                        if isBtaggedSFDn_uncorrelated:
-                            nCleanedJetsPt30BTagged_bTagSFDn_uncorrelated += 1
+                        # if isBtaggedSFUp_correlated:
+                        #     nCleanedJetsPt30BTagged_bTagSFUp_correlated += 1
+                        # if isBtaggedSFUp_uncorrelated:
+                        #     nCleanedJetsPt30BTagged_bTagSFUp_uncorrelated += 1
+                        # if isBtaggedSFDn_correlated:
+                        #     nCleanedJetsPt30BTagged_bTagSFDn_correlated += 1
+                        # if isBtaggedSFDn_uncorrelated:
+                        #     nCleanedJetsPt30BTagged_bTagSFDn_uncorrelated += 1
                 
                         # IDX of Leading/subleading jets passing all selections (including pT).
                         # Note: we cannot rely on the fact that the jet collection is sorted by pt since JES can change this.  
@@ -131,17 +133,18 @@ class jetFiller(Module):
         
         self.out.fillBranch("Jet_ZZMask", mask)
         self.out.fillBranch("Jet_ZZLepEF", jet_lepPtF)
+        self.out.fillBranch("Jet_ptThreshold", jet_ptThreshold)
         self.out.fillBranch("JetLeadingIdx", leadingJetIdx)
         self.out.fillBranch("JetSubleadingIdx", subleadingJetIdx)
         self.out.fillBranch("nCleanedJetsPt30", nCleanedJetsPt30)
-        self.out.fillBranch("nCleanedJetsPt30_jesUp", nCleanedJetsPt30_jesUp)
-        self.out.fillBranch("nCleanedJetsPt30_jesDn", nCleanedJetsPt30_jesDn)
+        # self.out.fillBranch("nCleanedJetsPt30_jesUp", nCleanedJetsPt30_jesUp)
+        # self.out.fillBranch("nCleanedJetsPt30_jesDn", nCleanedJetsPt30_jesDn)
         self.out.fillBranch("nCleanedJetsPt30BTagged", nCleanedJetsPt30BTagged)
         self.out.fillBranch("nCleanedJetsPt30BTagged_bTagSF", nCleanedJetsPt30BTagged_bTagSF)
-        self.out.fillBranch("nCleanedJetsPt30BTagged_bTagSFUp_correlated", nCleanedJetsPt30BTagged_bTagSFUp_correlated)
-        self.out.fillBranch("nCleanedJetsPt30BTagged_bTagSFUp_uncorrelated", nCleanedJetsPt30BTagged_bTagSFUp_uncorrelated)
-        self.out.fillBranch("nCleanedJetsPt30BTagged_bTagSFDn_correlated", nCleanedJetsPt30BTagged_bTagSFDn_correlated)
-        self.out.fillBranch("nCleanedJetsPt30BTagged_bTagSFDn_uncorrelated", nCleanedJetsPt30BTagged_bTagSFDn_uncorrelated)
+        # self.out.fillBranch("nCleanedJetsPt30BTagged_bTagSFUp_correlated", nCleanedJetsPt30BTagged_bTagSFUp_correlated)
+        # self.out.fillBranch("nCleanedJetsPt30BTagged_bTagSFUp_uncorrelated", nCleanedJetsPt30BTagged_bTagSFUp_uncorrelated)
+        # self.out.fillBranch("nCleanedJetsPt30BTagged_bTagSFDn_correlated", nCleanedJetsPt30BTagged_bTagSFDn_correlated)
+        # self.out.fillBranch("nCleanedJetsPt30BTagged_bTagSFDn_uncorrelated", nCleanedJetsPt30BTagged_bTagSFDn_uncorrelated)
 
         return True
 

--- a/NanoAnalysis/python/modules/jetBtagProducer.py
+++ b/NanoAnalysis/python/modules/jetBtagProducer.py
@@ -13,28 +13,28 @@ def getJetBtagProducer(era, tag, is_mc, is_signal, WP="M"):
         tagger = "particleNet"
         tagger_name = "btagPNetB"
         if "pre_EE" in tag:
-            json_SF = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/BTV/2022_Summer22/btagging.json.gz"
+            json_SF = "/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-22CDSep23-Summer22-NanoAODv12/2025-08-20/btagging.json.gz"
             json_eff = os.path.join(data_dir, f"btag_{'signal' if is_signal else 'background'}_2022.json.gz")
         else:
-            json_SF = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/BTV/2022_Summer22EE/btagging.json.gz"
+            json_SF = "/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-22EFGSep23-Summer22EE-NanoAODv12/2025-08-20/btagging.json.gz"
             json_eff = os.path.join(data_dir, f"btag_{'signal' if is_signal else 'background'}_2022EE.json.gz")
 
     elif era == 2023:
         tagger = "particleNet"
         tagger_name = "btagPNetB"
         if "pre_BPix" in tag:
-            json_SF = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/BTV/2023_Summer23/btagging.json.gz"
+            json_SF = "/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-23CSep23-Summer23-NanoAODv12/2025-08-20/btagging.json.gz"
             json_eff = os.path.join(data_dir, f"btag_{'signal' if is_signal else 'background'}_2022EE.json.gz")
             print("WARNING: using 2022 EE efficiency JSON for 2023 pre-BPix era. Please update this when the correct one is available.")
         else:
-            json_SF = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/BTV/2023_Summer23BPix/btagging.json.gz"
+            json_SF = "/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-23DSep23-Summer23BPix-NanoAODv12/2025-08-20/btagging.json.gz"
             json_eff = os.path.join(data_dir, f"btag_{'signal' if is_signal else 'background'}_2022EE.json.gz")
             print("WARNING: using 2022 EE efficiency JSON for 2023 post-BPix era. Please update this when the correct one is available.")
 
     elif era == 2024:
         tagger = "UParTAK4"
         tagger_name = "btagUParTAK4B"
-        json_SF = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/BTV/2024_Summer24/btagging.json.gz"
+        json_SF = "/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-03-10/btagging.json.gz"
         json_eff = os.path.join(data_dir, f"btag_{'signal' if is_signal else 'background'}_2022EE.json.gz")
         print("WARNING: using 2022 EE efficiency JSON for 2024 era. Please update this when the correct one is available.")
 
@@ -43,7 +43,7 @@ def getJetBtagProducer(era, tag, is_mc, is_signal, WP="M"):
         print("WARNING: official btagging json not available, using the one for 2022_Summer22")
         tagger = "particleNet"
         tagger_name = "btagPNetB"
-        json_SF = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/BTV/2022_Summer22/btagging.json.gz"
+        json_SF = "/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-22CDSep23-Summer22-NanoAODv12/2025-08-20/btagging.json.gz"
         json_eff = os.path.join(data_dir, f"btag_{'signal' if is_signal else 'background'}_2022.json.gz")
 
     else:

--- a/NanoAnalysis/python/modules/jetBtagProducer.py
+++ b/NanoAnalysis/python/modules/jetBtagProducer.py
@@ -4,7 +4,6 @@ Instantiate the correctionlib-based b-tagging module.
 
 import os
 
-
 def getJetBtagProducer(era, tag, is_mc, is_signal, WP="M"):
     from PhysicsTools.NATModules.modules.jetBtag import jetBtag
 
@@ -72,4 +71,4 @@ def getJetBtagProducer(era, tag, is_mc, is_signal, WP="M"):
         json_eff,
     )
 
-    return jetBtag(is_mc, tagger, tagger_name, WP, json_SF, json_eff)
+    return jetBtag(is_mc, tagger, tagger_name, WP, ["correlated","uncorrelated"], json_SF, json_eff)

--- a/NanoAnalysis/python/modules/jetBtagProducer.py
+++ b/NanoAnalysis/python/modules/jetBtagProducer.py
@@ -71,4 +71,4 @@ def getJetBtagProducer(era, tag, is_mc, is_signal, WP="M"):
         json_eff,
     )
 
-    return jetBtag(is_mc, tagger, tagger_name, WP, ["correlated","uncorrelated"], json_SF, json_eff)
+    return jetBtag(is_mc, tagger, tagger_name, WP, json_SF, json_eff, ["correlated","uncorrelated"])

--- a/NanoAnalysis/python/modules/jetIdProducer.py
+++ b/NanoAnalysis/python/modules/jetIdProducer.py
@@ -7,23 +7,23 @@ def getJetIdProducer(era, tag) :
     
     if era == 2022:
         if "pre_EE" in tag:
-            json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22/jetid.json.gz" #md5sum: 2070556451837fe611d6e0b0218a5d1f
+            json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/2026-04-13/jetid.json.gz"
         else:
-            json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22EE/jetid.json.gz" # Note: file is a link to the 2022_Summer22 file
+            json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-04-13/jetid.json.gz"
     
     elif era == 2023:
         if "pre_BPix" in tag:
-            json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2023_Summer23/jetid.json.gz" # Note: file is a link to the 2022_Summer22 file
+            json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23CSep23-Summer23-NanoAODv12/2026-04-13/jetid.json.gz"
         else:
-            json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2023_Summer23BPix/jetid.json.gz" # Note: file is a link to the 2022_Summer22 file
+            json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-23DSep23-Summer23BPix-NanoAODv12/2026-04-13/jetid.json.gz"
 
     elif era == 2024:
-       json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-07-17/jetid.json.gz" #from new versioned repository; identical to 2022_Summer22
+       json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-12-02/jetid.json.gz" #from new versioned repository; identical to 2022_Summer22
 
     elif era >= 2016 and era <=2018:
         # FIXME: Assume the same as 2022_Summer22 since json file is not present in official repositories
         print("WARNING: official jetid json not available, using the one for 2022_Summer22")
-        json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/2022_Summer22/jetid.json.gz"
+        json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/Run3-22CDSep23-Summer22-NanoAODv12/2026-04-13/jetid.json.gz"
 
     else: 
         raise ValueError("getJetIdProducer: get: Era", era, tag, "not supported")  

--- a/NanoAnalysis/python/modules/jetJERC.py
+++ b/NanoAnalysis/python/modules/jetJERC.py
@@ -57,7 +57,7 @@ def getJetCorrected(era, tag, is_mc, useJesSplittingScheme11, overwritePt=True) 
     elif era == 2022:
         if is_mc :
             if "pre_EE" in tag:
-                folderKey = "Run3-22CDSep23-Summer22-NanoAODv12/2025-09-23"
+                folderKey = "Run3-22CDSep23-Summer22-NanoAODv12/2026-04-13"
                 L1Key = "Summer22_22Sep2023_V3_MC_L1FastJet_AK4PFPuppi"
                 L2Key = "Summer22_22Sep2023_V3_MC_L2Relative_AK4PFPuppi"
                 L3Key = "Summer22_22Sep2023_V3_MC_L3Absolute_AK4PFPuppi"
@@ -70,7 +70,7 @@ def getJetCorrected(era, tag, is_mc, useJesSplittingScheme11, overwritePt=True) 
                 JERKey = "Summer22_22Sep2023_JRV1_MC_PtResolution_AK4PFPuppi"
                 JERsfKey = "Summer22_22Sep2023_JRV1_MC_ScaleFactor_AK4PFPuppi"
             else:
-                folderKey = "Run3-22EFGSep23-Summer22EE-NanoAODv12/2025-10-07"
+                folderKey = "Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-04-13"
                 L1Key = "Summer22EE_22Sep2023_V3_MC_L1FastJet_AK4PFPuppi"
                 L2Key = "Summer22EE_22Sep2023_V3_MC_L2Relative_AK4PFPuppi"
                 L3Key = "Summer22EE_22Sep2023_V3_MC_L3Absolute_AK4PFPuppi"
@@ -86,69 +86,45 @@ def getJetCorrected(era, tag, is_mc, useJesSplittingScheme11, overwritePt=True) 
         ## JER are not applied to data
         else :
             if "pre_EE" in tag:
-                folderKey = "Run3-22CDSep23-Summer22-NanoAODv12/2025-09-23"
-                L1Key = "Summer22_22Sep2023_RunCD_V3_DATA_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer22_22Sep2023_RunCD_V3_DATA_L2Relative_AK4PFPuppi"
-                L3Key = "Summer22_22Sep2023_RunCD_V3_DATA_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer22_22Sep2023_RunCD_V3_DATA_L2L3Residual_AK4PFPuppi"
-                scaleTotalKey = None
-                scaleKeyRegrouped11 = None 
-                smearKey = None
-                JERKey = None
-                JERsfKey = None
-            elif "2022E" in tag:
-                folderKey = "Run3-22EFGSep23-Summer22EE-NanoAODv12/2025-10-07"
-                L1Key = "Summer22EE_22Sep2023_RunE_V3_DATA_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer22EE_22Sep2023_RunE_V3_DATA_L2Relative_AK4PFPuppi"
-                L3Key = "Summer22EE_22Sep2023_RunE_V3_DATA_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer22EE_22Sep2023_RunE_V3_DATA_L2L3Residual_AK4PFPuppi"
-                scaleTotalKey = None
-                scaleKeyRegrouped11 = None 
-                smearKey = None
-                JERKey = None
-                JERsfKey = None
-            elif "2022F" in tag:
-                folderKey = "Run3-22EFGSep23-Summer22EE-NanoAODv12/2025-10-07"
-                L1Key = "Summer22EE_22Sep2023_RunF_V3_DATA_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer22EE_22Sep2023_RunF_V3_DATA_L2Relative_AK4PFPuppi"
-                L3Key = "Summer22EE_22Sep2023_RunF_V3_DATA_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer22EE_22Sep2023_RunF_V3_DATA_L2L3Residual_AK4PFPuppi"
-                scaleTotalKey = None
-                scaleKeyRegrouped11 = None 
-                smearKey = None
-                JERKey = None
-                JERsfKey = None
-            elif "2022G" in tag:
-                folderKey = "Run3-22EFGSep23-Summer22EE-NanoAODv12/2025-10-07"
-                L1Key = "Summer22EE_22Sep2023_RunG_V3_DATA_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer22EE_22Sep2023_RunG_V3_DATA_L2Relative_AK4PFPuppi"
-                L3Key = "Summer22EE_22Sep2023_RunG_V3_DATA_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer22EE_22Sep2023_RunG_V3_DATA_L2L3Residual_AK4PFPuppi"
+                folderKey = "Run3-22CDSep23-Summer22-NanoAODv12/2026-04-13"
+                L1Key = "Summer22_22Sep2023_V3_DATA_L1FastJet_AK4PFPuppi"
+                L2Key = "Summer22_22Sep2023_V3_DATA_L2Relative_AK4PFPuppi"
+                L3Key = "Summer22_22Sep2023_V3_DATA_L3Absolute_AK4PFPuppi"
+                L2L3Key = "Summer22_22Sep2023_V3_DATA_L2L3Residual_AK4PFPuppi"
                 scaleTotalKey = None
                 scaleKeyRegrouped11 = None 
                 smearKey = None
                 JERKey = None
                 JERsfKey = None
             else:
-                raise ValueError("getJetCorrected: tag", era, "not supported")
+                folderKey = "Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-04-13"
+                L1Key = "Summer22EE_22Sep2023_V3_DATA_L1FastJet_AK4PFPuppi"
+                L2Key = "Summer22EE_22Sep2023_V3_DATA_L2Relative_AK4PFPuppi"
+                L3Key = "Summer22EE_22Sep2023_V3_DATA_L3Absolute_AK4PFPuppi"
+                L2L3Key = "Summer22EE_22Sep2023_V3_DATA_L2L3Residual_AK4PFPuppi"
+                scaleTotalKey = None
+                scaleKeyRegrouped11 = None 
+                smearKey = None
+                JERKey = None
+                JERsfKey = None
 
     elif era == 2023:
         if is_mc :
             if "pre_BPix" in tag:
-                folderKey = "Run3-23CSep23-Summer23-NanoAODv12/2025-10-07"
-                L1Key = "Summer23Prompt23_V2_MC_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer23Prompt23_V2_MC_L2Relative_AK4PFPuppi"
-                L3Key = "Summer23Prompt23_V2_MC_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer23Prompt23_V2_MC_L2L3Residual_AK4PFPuppi"
-                scaleTotalKey = "Summer23Prompt23_V2_MC_Total_AK4PFPuppi"
+                folderKey = "Run3-23CSep23-Summer23-NanoAODv12/2026-04-13"
+                L1Key = "Summer23Prompt23_V3_MC_L1FastJet_AK4PFPuppi"
+                L2Key = "Summer23Prompt23_V3_MC_L2Relative_AK4PFPuppi"
+                L3Key = "Summer23Prompt23_V3_MC_L3Absolute_AK4PFPuppi"
+                L2L3Key = "Summer23Prompt23_V3_MC_L2L3Residual_AK4PFPuppi"
+                scaleTotalKey = "Summer23Prompt23_V3_MC_Total_AK4PFPuppi"
                 scaleKeyRegrouped11 = [
-                f"Summer23Prompt23_V2_MC_{label.format(year='2023')}_AK4PFPuppi" for label in jes_systematics_11split
+                f"Summer23Prompt23_V3_MC_{label.format(year='2023')}_AK4PFPuppi" for label in jes_systematics_11split
                 ]
                 smearKey = "JERSmear"
                 JERKey = "Summer23Prompt23_RunCv1234_JRV1_MC_PtResolution_AK4PFPuppi"
                 JERsfKey = "Summer23Prompt23_RunCv1234_JRV1_MC_ScaleFactor_AK4PFPuppi"
             else:
-                folderKey = "Run3-23DSep23-Summer23BPix-NanoAODv12/2025-10-07"
+                folderKey = "Run3-23DSep23-Summer23BPix-NanoAODv12/2026-04-13"
                 L1Key = "Summer23BPixPrompt23_V3_MC_L1FastJet_AK4PFPuppi"
                 L2Key = "Summer23BPixPrompt23_V3_MC_L2Relative_AK4PFPuppi"
                 L3Key = "Summer23BPixPrompt23_V3_MC_L3Absolute_AK4PFPuppi"
@@ -164,11 +140,11 @@ def getJetCorrected(era, tag, is_mc, useJesSplittingScheme11, overwritePt=True) 
         ## JER are not applied to data
         else :
             if "pre_BPix" in tag:
-                folderKey = "Run3-23CSep23-Summer23-NanoAODv12/2025-10-07"
-                L1Key = "Summer23Prompt23_V2_DATA_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer23Prompt23_V2_DATA_L2Relative_AK4PFPuppi"
-                L3Key = "Summer23Prompt23_V2_DATA_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer23Prompt23_V2_DATA_L2L3Residual_AK4PFPuppi"
+                folderKey = "Run3-23CSep23-Summer23-NanoAODv12/2026-04-13"
+                L1Key = "Summer23Prompt23_V3_DATA_L1FastJet_AK4PFPuppi"
+                L2Key = "Summer23Prompt23_V3_DATA_L2Relative_AK4PFPuppi"
+                L3Key = "Summer23Prompt23_V3_DATA_L3Absolute_AK4PFPuppi"
+                L2L3Key = "Summer23Prompt23_V3_DATA_L2L3Residual_AK4PFPuppi"
                 scaleTotalKey = None
                 scaleKeyRegrouped11 = None 
                 smearKey = None
@@ -188,14 +164,14 @@ def getJetCorrected(era, tag, is_mc, useJesSplittingScheme11, overwritePt=True) 
 
     elif era == 2024:
         if is_mc :
-            folderKey = "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-07-17"
-            L1Key = "Summer24Prompt24_V1_MC_L1FastJet_AK4PFPuppi"
-            L2Key = "Summer24Prompt24_V1_MC_L2Relative_AK4PFPuppi"
-            L3Key = "Summer24Prompt24_V1_MC_L3Absolute_AK4PFPuppi"
-            L2L3Key = "Summer24Prompt24_V1_MC_L2L3Residual_AK4PFPuppi"
-            scaleTotalKey = "Summer24Prompt24_V1_MC_Total_AK4PFPuppi"
+            folderKey = "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-12-02"
+            L1Key = "Summer24Prompt24_V2_MC_L1FastJet_AK4PFPuppi"
+            L2Key = "Summer24Prompt24_V2_MC_L2Relative_AK4PFPuppi"
+            L3Key = "Summer24Prompt24_V2_MC_L3Absolute_AK4PFPuppi"
+            L2L3Key = "Summer24Prompt24_V2_MC_L2L3Residual_AK4PFPuppi"
+            scaleTotalKey = "Summer24Prompt24_V2_MC_Total_AK4PFPuppi"
             scaleKeyRegrouped11 = [
-                f"Summer24Prompt24_V1_MC_{label.format(year='2024')}_AK4PFPuppi" for label in jes_systematics_11split
+                f"Summer24Prompt24_V2_MC_{label.format(year='2024')}_AK4PFPuppi" for label in jes_systematics_11split
                 ]
             smearKey = "JERSmear"
             # It appears the 23Bpix keys are used for the following:
@@ -208,11 +184,11 @@ def getJetCorrected(era, tag, is_mc, useJesSplittingScheme11, overwritePt=True) 
             # L2Key = "Winter24Prompt24_V3_DATA_L2Relative_AK4PFPuppi"
             # L3Key = "Winter24Prompt24_V3_DATA_L3Absolute_AK4PFPuppi"
             # L2L3Key = "Winter24Prompt24_V3_DATA_L2L3Residual_AK4PFPuppi"
-            folderKey = "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-07-17"
-            L1Key = "Summer24Prompt24_V1_DATA_L1FastJet_AK4PFPuppi"
-            L2Key = "Summer24Prompt24_V1_DATA_L2Relative_AK4PFPuppi"
-            L3Key = "Summer24Prompt24_V1_DATA_L3Absolute_AK4PFPuppi"
-            L2L3Key = "Summer24Prompt24_V1_DATA_L2L3Residual_AK4PFPuppi"
+            folderKey = "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-12-02"
+            L1Key = "Summer24Prompt24_V2_DATA_L1FastJet_AK4PFPuppi"
+            L2Key = "Summer24Prompt24_V2_DATA_L2Relative_AK4PFPuppi"
+            L3Key = "Summer24Prompt24_V2_DATA_L3Absolute_AK4PFPuppi"
+            L2L3Key = "Summer24Prompt24_V2_DATA_L2L3Residual_AK4PFPuppi"
             scaleTotalKey = None
             scaleKeyRegrouped11 = None 
             smearKey = None
@@ -222,14 +198,14 @@ def getJetCorrected(era, tag, is_mc, useJesSplittingScheme11, overwritePt=True) 
     else:
         raise ValueError("getJetCorrected: Era", era, tag, "not supported")
 
-            
+
     json_JERC = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/%s/jet_jerc.json.gz" % (folderKey)
-    json_JERsmear = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/JME/jer_smear.json.gz" # md5sum: 390e4be4be109bb1a2d3a116f2c9386a
+    json_JERsmear = "/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/JER-Smearing/2025-11-03/jer_smear.json.gz"
 
     # Determine usePhiDependentJEC based on the tag
     usePhiDependentJEC = era >= 2023 and not ("pre_BPix" in tag) # False up to 2023 pre_BPix, True in 2023 post_BPix and afterwards
     # Apply run-dependent JEC only for 2023 data (not MC)
-    useRunDependentJEC = (era == 2023 or era == 2024 or era == 2025) and (not is_mc)
+    useRunDependentJEC = (era == 2022 or era == 2023 or era == 2024 or era == 2025) and (not is_mc)
     # Use Splittign scheme for Jets uncertainties (11 sources)
 
     scaleKey = scaleKeyRegrouped11 if useJesSplittingScheme11 else scaleTotalKey

--- a/NanoAnalysis/python/modules/jetJERC.py
+++ b/NanoAnalysis/python/modules/jetJERC.py
@@ -1,4 +1,4 @@
-def getJetCorrected(era, tag, is_mc, overwritePt=True) :
+def getJetCorrected(era, tag, is_mc, useJesSplittingScheme11, overwritePt=True) :
     from PhysicsTools.NATModules.modules.jetCorr import jetJERC
 
 
@@ -231,7 +231,6 @@ def getJetCorrected(era, tag, is_mc, overwritePt=True) :
     # Apply run-dependent JEC only for 2023 data (not MC)
     useRunDependentJEC = (era == 2023 or era == 2024 or era == 2025) and (not is_mc)
     # Use Splittign scheme for Jets uncertainties (11 sources)
-    useJesSplittingScheme11 = False # Default
 
     scaleKey = scaleKeyRegrouped11 if useJesSplittingScheme11 else scaleTotalKey
 

--- a/NanoAnalysis/python/modules/jetVMAP.py
+++ b/NanoAnalysis/python/modules/jetVMAP.py
@@ -6,24 +6,24 @@ def getJetVetoMap(era, tag) :
 
     if era == 2022:
             if "pre_EE" in tag:
-                folderKey = "Run3-22CDSep23-Summer22-NanoAODv12/2025-09-23" # md5sum: e35eddf2b2eb072be63c78035cba01b0
+                folderKey = "Run3-22CDSep23-Summer22-NanoAODv12/2026-04-13"
                 corrName = "Summer22_23Sep2023_RunCD_V1"
             else:
-                folderKey = "Run3-22EFGSep23-Summer22EE-NanoAODv12/2025-10-07" # md5sum: ea16a7d736eacd58677dd761172792aa
+                folderKey = "Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-04-13"
                 corrName = "Summer22EE_23Sep2023_RunEFG_V1"
     
     elif era == 2023:
             if "pre_BPix" in tag:
-                folderKey = "Run3-23CSep23-Summer23-NanoAODv12/2025-10-07" # md5sum: 6e5ea1c9e7303dc72485303b1a6565b2
+                folderKey = "Run3-23CSep23-Summer23-NanoAODv12/2026-04-13"
                 corrName = "Summer23Prompt23_RunC_V1"
             else:
-                folderKey = "Run3-23DSep23-Summer23BPix-NanoAODv12/2025-10-07" # md5sum: 1f296a697ca06593ad36a7d53b56fa77
+                folderKey = "Run3-23DSep23-Summer23BPix-NanoAODv12/2026-04-13"
                 corrName = "Summer23BPixPrompt23_RunD_V1"
 
     elif era == 2024:
         # folderKey = "2024_Winter24" # md5sum: 802a8be50fde0fd45d86c98ea446b16b
         # corrName = "Winter24Prompt2024BCDEFGHI_V1"
-        folderKey = "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-07-17" # md5sum: 1cf19b46f969dbd31cb07e664dcca3cf
+        folderKey = "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-12-02" # md5sum: 1cf19b46f969dbd31cb07e664dcca3cf
         corrName = "Summer24Prompt24_RunBCDEFGHI_V1"
 
     json_JVMAP = f"/cvmfs/cms-griddata.cern.ch/cat/metadata/JME/{folderKey}/jetvetomaps.json.gz"

--- a/NanoAnalysis/python/modules/puWeightProducer.py
+++ b/NanoAnalysis/python/modules/puWeightProducer.py
@@ -231,29 +231,29 @@ def puWeight(era, data_tag):
         
         from PhysicsTools.NATModules.modules.puWeightProducer import puWeightProducer as puWeightProducer_corrlib
         if "pre_EE" in data_tag :
-            json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2022_Summer22/puWeights.json.gz" # md5sum: 4ace5f732cc3fe8ba2ed816b6f76d60a
+            json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/LUM/Run3-22CDSep23-Summer22-NanoAODv12/2024-01-31/puWeights.json.gz"
             key = "Collisions2022_355100_357900_eraBCD_GoldenJson"
         else :
-            json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2022_Summer22EE/puWeights.json.gz" # md5sum: d959ba71b4f10fbe8517bff06f5bd11f  
+            json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/LUM/Run3-22EFGSep23-Summer22EE-NanoAODv12/2024-01-31/puWeights.json.gz"
             key = "Collisions2022_359022_362760_eraEFG_GoldenJson"
         return puWeightProducer_corrlib(json, key)
 
     elif era == 2023 :
         from PhysicsTools.NATModules.modules.puWeightProducer import puWeightProducer as puWeightProducer_corrlib
         if "pre_BPix" in data_tag :
-            json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2023_Summer23/puWeights.json.gz" # md5sum: 6c70dd5f5b08e0d7c49a47282f2b64a9
+            json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/LUM/Run3-23CSep23-Summer23-NanoAODv12/2024-01-31/puWeights.json.gz"
             key = "Collisions2023_366403_369802_eraBC_GoldenJson"
         else :
-            json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/LUM/2023_Summer23BPix/puWeights.json.gz" # md5sum: fe3eb93fc147cf30247980325869145a
+            json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/LUM/Run3-23DSep23-Summer23BPix-NanoAODv12/2024-01-31/puWeights.json.gz"
             key = "Collisions2023_369803_370790_eraD_GoldenJson"
         return puWeightProducer_corrlib(json, key)
 
 
     elif era == 2024:
         from PhysicsTools.NATModules.modules.puWeightProducer import puWeightProducer as puWeightProducer_corrlib
-        json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/LUM/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-12-02/puWeights_BCDEFGHI.json.gz"
+        json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/LUM/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-04-15/puWeights_BCDEFGHI.json.gz"
         key = "Collisions24_BCDEFGHI_goldenJSON"
-        return puWeightProducer_corrlib(json, key)
+        return puWeightProducer_corrlib(json, key) 
 
     else:
         raise ValueError(f"Era {era} not supported yet")

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -56,6 +56,7 @@ APPLY_K_NNLOEW_ZZQQB  = getConf("APPLY_K_NNLOEW_ZZQQB", False)
 IsSIGNAL = getConf("IsSIGNAL", False)
 ADD_ALLEVENTS = getConf("ADD_ALLEVENTS", IsSIGNAL) # if true, add a separate tree with gen-level variables for all events (not just those passing the candidate selection); by default, this is done for signal samples
 ADD_LHE_PROB = getConf("ADD_LHE_PROB", ADD_ALLEVENTS) # Add LHE angles and probabilities. This is in general the case whenever ADD_ALLEVENTS is true (ie for signals)
+JES_SPLITTING = getConf("JES_SPLITTING", True) # Whether to split JES variations into 11 components (if false, only up/down variations are produced, by summing all components in quadrature)
 
 FILTER_EVENTS = getConf("FILTER_EVENTS", 'Cands') # Filter to be applied on events. Currently supported:
                                                   # 'Cands' = any event with a SR or CR candidate (default)
@@ -228,7 +229,7 @@ elif NANOVERSION >=13 :
 # Add jet corrections for Run 3
 if APPLYJETCORR and LEPTON_SETUP >=2022 :
     from ZZAnalysis.NanoAnalysis.modules.jetJERC import getJetCorrected
-    insertBefore(reco_sequence, 'jetFiller', getJetCorrected(LEPTON_SETUP, DATA_TAG, IsMC, overwritePt=True))
+    insertBefore(reco_sequence, 'jetFiller', getJetCorrected(LEPTON_SETUP, DATA_TAG, IsMC, JES_SPLITTING, overwritePt=True))
     from ZZAnalysis.NanoAnalysis.modules.jetVMAP import getJetVetoMap
     insertBefore(reco_sequence, 'jetFiller', getJetVetoMap(LEPTON_SETUP, DATA_TAG))
 

--- a/NanoAnalysis/python/weightFiller.py
+++ b/NanoAnalysis/python/weightFiller.py
@@ -47,8 +47,7 @@ class weightFiller(Module):
         # ggH NNLOPS weights
         if self.APPLY_QCD_GGF_UNCERT :
             if self.LEPTON_SETUP >= 2022:
-                NNLOPS_weight_file = ROOT.TFile.Open(basePath+'data/ggH_NNLOPS_Weights/NNLOPS_reweight.root')
-                print("WARNING: since the current NNLOPS weights for ggF signals didn't consider the finite top mass effects (from Adinda), we still use the 13 TeV one.")
+                NNLOPS_weight_file = ROOT.TFile.Open(basePath+'data/ggH_NNLOPS_Weights/NNLOPS_reweight_13p6.root')
             else:
                 NNLOPS_weight_file = ROOT.TFile.Open(basePath+'data/ggH_NNLOPS_Weights/NNLOPS_reweight.root')
             self.gr_NNLOPSratio_pt_powheg_0jet = NNLOPS_weight_file.Get("gr_NNLOPSratio_pt_powheg_0jet")

--- a/NanoAnalysis/python/weightFiller.py
+++ b/NanoAnalysis/python/weightFiller.py
@@ -47,7 +47,8 @@ class weightFiller(Module):
         # ggH NNLOPS weights
         if self.APPLY_QCD_GGF_UNCERT :
             if self.LEPTON_SETUP >= 2022:
-                NNLOPS_weight_file = ROOT.TFile.Open(basePath+'data/ggH_NNLOPS_Weights/NNLOPS_reweight_13p6.root')
+                NNLOPS_weight_file = ROOT.TFile.Open(basePath+'data/ggH_NNLOPS_Weights/NNLOPS_reweight.root')
+                print("WARNING: since the current NNLOPS weights for ggF signals didn't consider the finite top mass effects (from Adinda), we still use the 13 TeV one.")
             else:
                 NNLOPS_weight_file = ROOT.TFile.Open(basePath+'data/ggH_NNLOPS_Weights/NNLOPS_reweight.root')
             self.gr_NNLOPSratio_pt_powheg_0jet = NNLOPS_weight_file.Get("gr_NNLOPSratio_pt_powheg_0jet")
@@ -120,7 +121,7 @@ class weightFiller(Module):
             htxsNJets = event.HTXS_njets30
             htxsHPt = event.HTXS_Higgs_pt
             if htxsNJets==0 :
-                ggH_NNLOPS_Weight = self.gr_NNLOPSratio_pt_powheg_0jet.Eval(min(htxsHPt, 125.0))
+                ggH_NNLOPS_Weight = self.gr_NNLOPSratio_pt_powheg_0jet.Eval(min(htxsHPt,125.0))
             elif htxsNJets==1 :
                 ggH_NNLOPS_Weight = self.gr_NNLOPSratio_pt_powheg_1jet.Eval(min(htxsHPt,625.0))
             elif htxsNJets==2 :

--- a/NanoAnalysis/test/BtagEfficiency/btagEfficiency.py
+++ b/NanoAnalysis/test/BtagEfficiency/btagEfficiency.py
@@ -22,11 +22,15 @@ parser.add_argument("-y", "--year", default="2022EE")
 parser.add_argument("-l", "--lumi", default=26.7)
 parser.add_argument("-i", "--input", default="/eos/user/a/atarabin/STXS_samples/PROD_samplesNano_2022EE_MC_8d4c03f7/")
 parser.add_argument("-m", "--hist-mode", choices=["make", "read"], default="make", help="Make histograms from NanoAOD inputs or read them from the saved ROOT file.")
+parser.add_argument("-s", "--is-signal", )
 args = parser.parse_args()
 
 class btagEffCalculator():
-    def __init__(self, year, lumi, input_dir):
-        self.processes = ["ggH125","VBFH125","WplusH125","WminusH125","ZH125","ttH125","ZZTo4l","ggTo2e2mu_Contin_MCFM701","ggTo2e2tau_Contin_MCFM701","ggTo2mu2tau_Contin_MCFM701","ggTo4e_Contin_MCFM701","ggTo4mu_Contin_MCFM701","ggTo4tau_Contin_MCFM701","WWZ","WZZ","ZZZ","TTWW","TTZZ"]
+    def __init__(self, year, lumi, input_dir, isSignal=True):
+        if isSignal:
+            self.processes = ["ggH125","VBFH125","WplusH125","WminusH125","ZH125","ttH125"]
+        else:
+            self.processes = ["ZZTo4l","ggTo2e2mu_Contin_MCFM701","ggTo2e2tau_Contin_MCFM701","ggTo2mu2tau_Contin_MCFM701","ggTo4e_Contin_MCFM701","ggTo4mu_Contin_MCFM701","ggTo4tau_Contin_MCFM701","WWZ","WZZ","ZZZ","TTWW","TTZZ"]
 
         self.year = year
         self.lumi = float(lumi)
@@ -132,6 +136,9 @@ class btagEffCalculator():
         h_all = {}
         h_tagged = {}
         h_eff = {}
+        h_all_err = {}
+        h_tagged_err = {}
+        h_eff_err = {}
 
         for name, mask in flavor_masks.items():
 
@@ -142,6 +149,13 @@ class btagEffCalculator():
                 bins=[self.pt_edges, self.eta_edges],
                 weights=weight[mask]
             )
+            h_all_sumw2, _, _ = np.histogram2d(
+                pt[mask],
+                eta[mask],
+                bins=[self.pt_edges, self.eta_edges],
+                weights=weight[mask] * weight[mask]
+            )
+            h_all_err[name] = np.sqrt(h_all_sumw2)
 
             # tagged jets
             tagged_mask = mask & (tagger > self.WP)
@@ -152,31 +166,56 @@ class btagEffCalculator():
                 bins=[self.pt_edges, self.eta_edges],
                 weights=weight[tagged_mask]
             )
+            h_tagged_sumw2, _, _ = np.histogram2d(
+                pt[tagged_mask],
+                eta[tagged_mask],
+                bins=[self.pt_edges, self.eta_edges],
+                weights=weight[tagged_mask] * weight[tagged_mask]
+            )
+            h_tagged_err[name] = np.sqrt(h_tagged_sumw2)
             h_eff[name] = np.divide(
                 h_tagged[name],
                 h_all[name],
                 out=np.zeros_like(h_tagged[name], dtype=float),
                 where=h_all[name] > 0
             )
+            h_untagged_sumw2 = np.maximum(h_all_sumw2 - h_tagged_sumw2, 0.0)
+            h_eff_var = np.divide(
+                ((1.0 - h_eff[name]) ** 2) * h_tagged_sumw2
+                + (h_eff[name] ** 2) * h_untagged_sumw2,
+                h_all[name] * h_all[name],
+                out=np.zeros_like(h_eff[name], dtype=float),
+                where=h_all[name] > 0
+            )
+            h_eff_err[name] = np.sqrt(np.maximum(h_eff_var, 0.0))
 
-        return h_all, h_tagged, h_eff
+        return h_all, h_tagged, h_eff, h_all_err, h_tagged_err, h_eff_err
 
     def read_histograms(self, filename):
         if not os.path.exists(filename):
             raise FileNotFoundError(f"Histogram file not found: {filename}")
 
-        def th2_to_array(hist):
+        def th2_to_arrays(hist):
             nx = hist.GetNbinsX()
             ny = hist.GetNbinsY()
-            out = np.zeros((nx, ny), dtype=float)
+            content = np.zeros((nx, ny), dtype=float)
+            error = np.zeros((nx, ny), dtype=float)
+            has_stored_errors = hist.GetSumw2N() > 0
+            if not has_stored_errors:
+                print(f"[read_histograms] Histogram '{hist.GetName()}' has no stored bin errors; using zero errors.")
             for ix in range(nx):
                 for iy in range(ny):
-                    out[ix, iy] = hist.GetBinContent(ix + 1, iy + 1)
-            return out
+                    content[ix, iy] = hist.GetBinContent(ix + 1, iy + 1)
+                    if has_stored_errors:
+                        error[ix, iy] = hist.GetBinError(ix + 1, iy + 1)
+            return content, error
 
         h_all = {}
         h_tagged = {}
         h_eff = {}
+        h_all_err = {}
+        h_tagged_err = {}
+        h_eff_err = {}
 
         f = ROOT.TFile.Open(filename)
         if not f or f.IsZombie():
@@ -193,29 +232,38 @@ class btagEffCalculator():
                 if not hist:
                     f.Close()
                     raise KeyError(f"Missing histogram '{hname}' in {filename}")
-                target[flav] = th2_to_array(hist)
+                content, error = th2_to_arrays(hist)
+                target[flav] = content
+                {
+                    "all": h_all_err,
+                    "tagged": h_tagged_err,
+                    "eff": h_eff_err,
+                }[suffix][flav] = error
 
         f.Close()
-        return h_all, h_tagged, h_eff
+        return h_all, h_tagged, h_eff, h_all_err, h_tagged_err, h_eff_err
 
-    def save_to_root(self, h_all, h_tagged, h_eff, filename):
+    def save_to_root(self, h_all, h_tagged, h_eff, filename, h_all_err=None, h_tagged_err=None, h_eff_err=None):
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         f = ROOT.TFile(filename, "RECREATE")
 
         for flav in h_all.keys():
-            for hname, hdata in [
-                (f"{flav}_all",    h_all[flav]),
-                (f"{flav}_tagged", h_tagged[flav]),
-                (f"{flav}_eff",    h_eff[flav]),
+            for hname, hdata, herr in [
+                (f"{flav}_all",    h_all[flav],    None if h_all_err is None else h_all_err[flav]),
+                (f"{flav}_tagged", h_tagged[flav], None if h_tagged_err is None else h_tagged_err[flav]),
+                (f"{flav}_eff",    h_eff[flav],    None if h_eff_err is None else h_eff_err[flav]),
             ]:
                 nx = len(self.pt_edges) - 1
                 ny = len(self.eta_edges) - 1
                 h = ROOT.TH2F(hname, hname,
                             nx, array('d', self.pt_edges),
                             ny, array('d', self.eta_edges))
+                h.Sumw2()
                 for ix in range(nx):
                     for iy in range(ny):
                         h.SetBinContent(ix + 1, iy + 1, hdata[ix, iy])
+                        if herr is not None:
+                            h.SetBinError(ix + 1, iy + 1, herr[ix, iy])
                 h.Write()
 
         f.Close()
@@ -295,12 +343,13 @@ class btagEffCalculator():
             else:
                 json.dump(cset.dict(exclude_unset=True), f, indent=2)
 
-    def plot_2d_hist(self, hist, name, outname, zmin=None, zmax=None, cmap="viridis"):
+    def plot_2d_hist(self, hist, name, outname, hist_err=None, zmin=None, zmax=None, cmap="viridis"):
 
         pt_edges = np.array(self.pt_edges)
         eta_edges = np.array(self.eta_edges)
 
         h = np.array(hist, dtype=float)
+        h_err = None if hist_err is None else np.array(hist_err, dtype=float)
         h_plot = np.ma.masked_less_equal(h, 0.0)
         positive = h[h > 0]
         log_vmin = zmin if zmin is not None and zmin > 0 else (positive.min() if positive.size else 1e-6)
@@ -319,6 +368,23 @@ class btagEffCalculator():
 
         fig.colorbar(mesh, ax=ax, label=name, pad=0.01)
 
+        if h_err is not None:
+            for ix in range(len(pt_edges) - 1):
+                x = 0.5 * (pt_edges[ix] + pt_edges[ix + 1])
+                for iy in range(len(eta_edges) - 1):
+                    if h[ix, iy] <= 0:
+                        continue
+                    y = 0.5 * (eta_edges[iy] + eta_edges[iy + 1])
+                    ax.text(
+                        x,
+                        y,
+                        f"{h[ix, iy]:.3g}\n+/- {h_err[ix, iy]:.2g}",
+                        ha="center",
+                        va="center",
+                        fontsize=10,
+                        color="white" if h[ix, iy] > np.sqrt(log_vmin * log_vmax) else "black",
+                    )
+
         ax.set_xlabel(r"$p_T$ [GeV]")
         ax.set_ylabel(r"$|\eta|$")
         hep.cms.label("Preliminary", data=False, lumi=self.lumi, com=13.6, ax=ax)
@@ -330,18 +396,32 @@ class btagEffCalculator():
 
         plt.close(fig)
 
-    def plot_1d_hist(self, hist, name, outname, ymin=1e-3, ymax=1.0):
+    def plot_1d_hist(self, hist, name, outname, hist_err=None, ymin=1e-3, ymax=1.0):
 
         pt_edges = np.array(self.pt_edges, dtype=float)
         eta_edges = np.array(self.eta_edges, dtype=float)
+        pt_centers = 0.5 * (pt_edges[:-1] + pt_edges[1:])
+        pt_widths = np.diff(pt_edges)
         h = np.array(hist, dtype=float)
+        h_err = None if hist_err is None else np.array(hist_err, dtype=float)
 
         fig, ax = plt.subplots(figsize=(11, 9))
 
         for i_eta in range(len(eta_edges) - 1):
-            y = np.ma.masked_less_equal(h[:, i_eta], 0.0)
+            valid = h[:, i_eta] > 0.0
+            y = np.ma.masked_where(~valid, h[:, i_eta])
             label = rf"${eta_edges[i_eta]:g} \leq |\eta| < {eta_edges[i_eta + 1]:g}$"
             ax.stairs(y, pt_edges, label=label, linewidth=2.5)
+            if h_err is not None:
+                ax.errorbar(
+                    pt_centers[valid],
+                    h[valid, i_eta],
+                    yerr=h_err[valid, i_eta],
+                    xerr=0.5 * pt_widths[valid],
+                    fmt="none",
+                    capsize=2,
+                    linewidth=1.5,
+                )
 
         ax.set_xlabel(r"$p_T$ [GeV]")
         ax.set_ylabel(name)
@@ -358,10 +438,12 @@ class btagEffCalculator():
 
         plt.close(fig)
 
-    def plot_1d_all_flavors(self, h_eff, outname, ymin=1e-3, ymax=1.0):
+    def plot_1d_all_flavors(self, h_eff, outname, h_eff_err=None, ymin=1e-3, ymax=1.0):
 
         pt_edges = np.array(self.pt_edges, dtype=float)
         eta_edges = np.array(self.eta_edges, dtype=float)
+        pt_centers = 0.5 * (pt_edges[:-1] + pt_edges[1:])
+        pt_widths = np.diff(pt_edges)
         flavors = ["light", "c", "b"]
         line_styles = {
             "light": "-",
@@ -375,8 +457,10 @@ class btagEffCalculator():
 
         for flav in flavors:
             h = np.array(h_eff[flav], dtype=float)
+            h_err = None if h_eff_err is None else np.array(h_eff_err[flav], dtype=float)
             for i_eta, color in enumerate(eta_colors):
-                y = np.ma.masked_less_equal(h[:, i_eta], 0.0)
+                valid = h[:, i_eta] > 0.0
+                y = np.ma.masked_where(~valid, h[:, i_eta])
                 ax.stairs(
                     y,
                     pt_edges,
@@ -384,6 +468,17 @@ class btagEffCalculator():
                     linestyle=line_styles[flav],
                     linewidth=2.5,
                 )
+                if h_err is not None:
+                    ax.errorbar(
+                        pt_centers[valid],
+                        h[valid, i_eta],
+                        yerr=h_err[valid, i_eta],
+                        xerr=0.5 * pt_widths[valid],
+                        fmt="none",
+                        ecolor=color,
+                        capsize=2,
+                        linewidth=1.2,
+                    )
 
         eta_handles = [
             Line2D(
@@ -453,15 +548,15 @@ class btagEffCalculator():
         plt.close(fig)
 
 
-btag = btagEffCalculator(args.year, args.lumi, args.input)
+btag = btagEffCalculator(args.year, args.lumi, args.input, args.is_signal)
 root_file = f"../../data/btagEff/btag_{args.year}.root"
 if args.hist_mode == "make":
-    h_all, h_tagged, h_eff = btag.make_histograms()
-    btag.save_to_root(h_all, h_tagged, h_eff, root_file)
+    h_all, h_tagged, h_eff, h_all_err, h_tagged_err, h_eff_err = btag.make_histograms()
+    btag.save_to_root(h_all, h_tagged, h_eff, root_file, h_all_err, h_tagged_err, h_eff_err)
 else:
-    h_all, h_tagged, h_eff = btag.read_histograms(root_file)
-btag.save_to_correctionlib_json(h_eff, f"../../data/btagEff/btag_{args.year}.json.gz")
-for flav in h_eff.keys():
-    btag.plot_2d_hist(h_eff[flav], f"b-tag efficiency for {flav} jets", f"../../data/btagEff/plots/btag_eff_{flav}_{args.year}_2d", zmin=0.006, zmax=1)
-    btag.plot_1d_hist(h_eff[flav], f"b-tag efficiency for {flav} jets", f"../../data/btagEff/plots/btag_eff_{flav}_{args.year}_1d", ymin=0.006, ymax=6)
-btag.plot_1d_all_flavors(h_eff, f"../../data/btagEff/plots/btag_eff_all_flavors_{args.year}_1d", ymin=0.006, ymax=2)
+    h_all, h_tagged, h_eff, h_all_err, h_tagged_err, h_eff_err = btag.read_histograms(root_file)
+btag.save_to_correctionlib_json(h_eff, f"../../data/btagEff/btag_{'signal' if args.is_signal else 'background'}_{args.year}.json.gz")
+# for flav in h_eff.keys():
+#     btag.plot_2d_hist(h_eff[flav], f"b-tag efficiency for {flav} jets", f"../../data/btagEff/plots/btag_eff_{flav}_{args.year}_2d", h_eff_err[flav], zmin=0.006, zmax=1)
+#     btag.plot_1d_hist(h_eff[flav], f"b-tag efficiency for {flav} jets", f"../../data/btagEff/plots/btag_eff_{flav}_{args.year}_1d", h_eff_err[flav], ymin=0.006, ymax=6)
+btag.plot_1d_all_flavors(h_eff, f"../../data/btagEff/plots/btag_eff_all_flavors_{args.year}_1d_{'signal' if args.is_signal else 'background'}", h_eff_err, ymin=0.006, ymax=2)

--- a/NanoAnalysis/test/BtagEfficiency/btagEfficiency.py
+++ b/NanoAnalysis/test/BtagEfficiency/btagEfficiency.py
@@ -54,15 +54,15 @@ class btagEffCalculator():
         self.arrays = None
 
         if self.year == "2022":
-            btag_json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/BTV/2022_Summer22/btagging.json.gz"
+            btag_json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-22CDSep23-Summer22-NanoAODv12/2025-08-20/btagging.json.gz"
         elif self.year == "2022EE":
-            btag_json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/BTV/2022_Summer22EE/btagging.json.gz"
+            btag_json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-22EFGSep23-Summer22EE-NanoAODv12/2025-08-20/btagging.json.gz"
         elif self.year == "2023":
-            btag_json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/BTV/2023_Summer23/btagging.json.gz"
+            btag_json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-23CSep23-Summer23-NanoAODv12/2025-08-20/btagging.json.gz"
         elif self.year == "2023BPix":
-            btag_json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/BTV/2023_Summer23BPix/btagging.json.gz"
+            btag_json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-23DSep23-Summer23BPix-NanoAODv12/2025-08-20/btagging.json.gz"
         elif self.year == "2024":
-            btag_json = "/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG/BTV/2024_Summer24/btagging.json.gz"
+            btag_json = "/cvmfs/cms-griddata.cern.ch/cat/metadata/BTV/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-03-10/btagging.json.gz"
         else:
             raise ValueError(f"Unsupported year: {self.year}")
 

--- a/NanoAnalysis/test/BtagEfficiency/run.sh
+++ b/NanoAnalysis/test/BtagEfficiency/run.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-python3 btagEfficiency.py -y 2022 -l 8 -i /eos/user/a/atarabin/STXS_samples/PROD_samplesNano_2022_MC_8d4c03f7
-python3 btagEfficiency.py -y 2022EE -l 26.7 -i /eos/user/a/atarabin/STXS_samples/PROD_samplesNano_2022EE_MC_8d4c03f7
-# python3 btagEfficiency.py -y 2023 -l 17.8 -i /eos/user/a/atarabin/STXS_samples/PROD_samplesNano_2023preBPix_MC_8d4c03f7
-# python3 btagEfficiency.py -y 2023BPix -l 9.5 -i /eos/user/a/atarabin/STXS_samples/PROD_samplesNano_2023postBPix_MC_8d4c03f7
+for s in 0 1
+do
+    python3 btagEfficiency.py -y 2022 -l 8 -i /eos/user/a/atarabin/STXS_samples/PROD_samplesNano_2022_MC_8d4c03f7 -s $s
+    python3 btagEfficiency.py -y 2022EE -l 26.7 -i /eos/user/a/atarabin/STXS_samples/PROD_samplesNano_2022EE_MC_8d4c03f7 -s $s
+    # python3 btagEfficiency.py -y 2023 -l 17.8 -i /eos/user/a/atarabin/STXS_samples/PROD_samplesNano_2023preBPix_MC_8d4c03f7 -s $s
+    # python3 btagEfficiency.py -y 2023BPix -l 9.5 -i /eos/user/a/atarabin/STXS_samples/PROD_samplesNano_2023postBPix_MC_8d4c03f7 -s $s
+done

--- a/checkout_13X.csh
+++ b/checkout_13X.csh
@@ -86,7 +86,7 @@ fi
    
 #get nanoAODTools modules
 git clone https://github.com/cms-cat/nanoAOD-tools-modules.git PhysicsTools/NATModules
-(cd PhysicsTools/NATModules; git checkout -b from-1a3d8a5 1a3d8a5)
+(cd PhysicsTools/NATModules; git checkout -b from-e1beaf3 e1beaf3)
 
 
 #CommonLHETools requires the MELA env to be set for compilation


### PR DESCRIPTION
Dear Experts,

This PR includes the following updates:
- The 11 sources of JES are by default turned on.
- In `jetFiller.py`, variations of nCleanedJets etc are not saved. I only kept the nominal one for quick checks. One will need to compute the variations in the preprocessor later.
- It is possible to keep different options of b-tagging SF uncertainties. By default, only two are kept: correlated and uncorrelated.
- The script in `test/BtagEfficiency/` is updated such that one can compute b-tagging efficiency separately (I have done this 2 weeks ago, should have updated this script earlier).
- Updated all used paths of json.gz files from `/cvmfs/cms.cern.ch/rsync/cms-nanoAOD/jsonpog-integration/POG` to `/cvmfs/cms-griddata.cern.ch/cat/metadata`. I also updated some jet-related files to the most updated ones so far. Electron-related are not updated yet, we can discuss. Muon-related ones are already the newest.

Thanks very much!

Yours Sincerely,
Glenn