### PR TITLE
Update JER SF unc treatment

### DIFF
--- a/NanoAnalysis/python/modules/jetJERC.py
+++ b/NanoAnalysis/python/modules/jetJERC.py
@@ -42,6 +42,7 @@ def getJetCorrected(era, tag, is_mc, useJesSplittingScheme11, overwritePt=True) 
             # It appears the most recent 23Bpix files are used in the following cases: 
             JERKey = "Summer19UL18_JRV2_MC_PtResolution_AK4PFchs"
             JERsfKey = "Summer19UL18_JRV2_MC_ScaleFactor_AK4PFchs"
+            JERsfUncKey = None
  
         else :
             L1Key = "Summer19UL18_RunA_V5_DATA_L1FastJet_AK4PFchs"
@@ -53,147 +54,157 @@ def getJetCorrected(era, tag, is_mc, useJesSplittingScheme11, overwritePt=True) 
             smearKey = None
             JERKey = None
             JERsfKey = None
+            JERsfUncKey = None
         
     elif era == 2022:
         if is_mc :
             if "pre_EE" in tag:
-                folderKey = "Run3-22CDSep23-Summer22-NanoAODv12/2026-04-13"
-                L1Key = "Summer22_22Sep2023_V3_MC_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer22_22Sep2023_V3_MC_L2Relative_AK4PFPuppi"
-                L3Key = "Summer22_22Sep2023_V3_MC_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer22_22Sep2023_V3_MC_L2L3Residual_AK4PFPuppi"
-                scaleTotalKey = "Summer22_22Sep2023_V3_MC_Total_AK4PFPuppi"
+                folderKey = "Run3-22CDSep23-Summer22-NanoAODv12/2026-06-05"
+                L1Key = "Summer22_22Sep2023_V4_MC_L1FastJet_AK4PFPuppi"
+                L2Key = "Summer22_22Sep2023_V4_MC_L2Relative_AK4PFPuppi"
+                L3Key = "Summer22_22Sep2023_V4_MC_L3Absolute_AK4PFPuppi"
+                L2L3Key = "Summer22_22Sep2023_V4_MC_L2L3Residual_AK4PFPuppi"
+                scaleTotalKey = "Summer22_22Sep2023_V4_MC_Total_AK4PFPuppi"
                 scaleKeyRegrouped11 = [
-                f"Summer22_22Sep2023_V3_MC_{label.format(year=era)}_AK4PFPuppi" for label in jes_systematics_11split
+                f"Summer22_22Sep2023_V4_MC_{label.format(year=era)}_AK4PFPuppi" for label in jes_systematics_11split
                 ]
                 smearKey = "JERSmear"
-                JERKey = "Summer22_22Sep2023_JRV1_MC_PtResolution_AK4PFPuppi"
-                JERsfKey = "Summer22_22Sep2023_JRV1_MC_ScaleFactor_AK4PFPuppi"
+                JERKey = "Summer22_22Sep2023_JRV2_MC_PtResolution_AK4PFPuppi"
+                JERsfKey = "Summer22_22Sep2023_JRV2_MC_ScaleFactor_AK4PFPuppi"
+                JERsfUncKey = "Summer22_22Sep2023_JRV2_MC_SFUncertainty_AK4PFPuppi"
             else:
-                folderKey = "Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-04-13"
-                L1Key = "Summer22EE_22Sep2023_V3_MC_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer22EE_22Sep2023_V3_MC_L2Relative_AK4PFPuppi"
-                L3Key = "Summer22EE_22Sep2023_V3_MC_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer22EE_22Sep2023_V3_MC_L2L3Residual_AK4PFPuppi"
-                scaleTotalKey = "Summer22EE_22Sep2023_V3_MC_Total_AK4PFPuppi"
+                folderKey = "Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-06-05"
+                L1Key = "Summer22EE_22Sep2023_V4_MC_L1FastJet_AK4PFPuppi"
+                L2Key = "Summer22EE_22Sep2023_V4_MC_L2Relative_AK4PFPuppi"
+                L3Key = "Summer22EE_22Sep2023_V4_MC_L3Absolute_AK4PFPuppi"
+                L2L3Key = "Summer22EE_22Sep2023_V4_MC_L2L3Residual_AK4PFPuppi"
+                scaleTotalKey = "Summer22EE_22Sep2023_V4_MC_Total_AK4PFPuppi"
                 scaleKeyRegrouped11 = [
-                f"Summer22EE_22Sep2023_V3_MC_{label.format(year='2022EE')}_AK4PFPuppi" for label in jes_systematics_11split
+                f"Summer22EE_22Sep2023_V4_MC_{label.format(year='2022EE')}_AK4PFPuppi" for label in jes_systematics_11split
                 ]
                 smearKey = "JERSmear"
-                JERKey = "Summer22EE_22Sep2023_JRV1_MC_PtResolution_AK4PFPuppi"
-                JERsfKey = "Summer22EE_22Sep2023_JRV1_MC_ScaleFactor_AK4PFPuppi"
+                JERKey = "Summer22EE_22Sep2023_JRV2_MC_PtResolution_AK4PFPuppi"
+                JERsfKey = "Summer22EE_22Sep2023_JRV2_MC_ScaleFactor_AK4PFPuppi"
+                JERsfUncKey = "Summer22EE_22Sep2023_JRV2_MC_SFUncertainty_AK4PFPuppi"
         ## Data
         ## JER are not applied to data
         else :
             if "pre_EE" in tag:
-                folderKey = "Run3-22CDSep23-Summer22-NanoAODv12/2026-04-13"
-                L1Key = "Summer22_22Sep2023_V3_DATA_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer22_22Sep2023_V3_DATA_L2Relative_AK4PFPuppi"
-                L3Key = "Summer22_22Sep2023_V3_DATA_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer22_22Sep2023_V3_DATA_L2L3Residual_AK4PFPuppi"
+                folderKey = "Run3-22CDSep23-Summer22-NanoAODv12/2026-06-05"
+                L1Key = "Summer22_22Sep2023_V4_DATA_L1FastJet_AK4PFPuppi"
+                L2Key = "Summer22_22Sep2023_V4_DATA_L2Relative_AK4PFPuppi"
+                L3Key = "Summer22_22Sep2023_V4_DATA_L3Absolute_AK4PFPuppi"
+                L2L3Key = "Summer22_22Sep2023_V4_DATA_L2L3Residual_AK4PFPuppi"
                 scaleTotalKey = None
                 scaleKeyRegrouped11 = None 
                 smearKey = None
                 JERKey = None
                 JERsfKey = None
+                JERsfUncKey = None
             else:
-                folderKey = "Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-04-13"
-                L1Key = "Summer22EE_22Sep2023_V3_DATA_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer22EE_22Sep2023_V3_DATA_L2Relative_AK4PFPuppi"
-                L3Key = "Summer22EE_22Sep2023_V3_DATA_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer22EE_22Sep2023_V3_DATA_L2L3Residual_AK4PFPuppi"
+                folderKey = "Run3-22EFGSep23-Summer22EE-NanoAODv12/2026-06-05"
+                L1Key = "Summer22EE_22Sep2023_V4_DATA_L1FastJet_AK4PFPuppi"
+                L2Key = "Summer22EE_22Sep2023_V4_DATA_L2Relative_AK4PFPuppi"
+                L3Key = "Summer22EE_22Sep2023_V4_DATA_L3Absolute_AK4PFPuppi"
+                L2L3Key = "Summer22EE_22Sep2023_V4_DATA_L2L3Residual_AK4PFPuppi"
                 scaleTotalKey = None
                 scaleKeyRegrouped11 = None 
                 smearKey = None
                 JERKey = None
                 JERsfKey = None
+                JERsfUncKey = None
 
     elif era == 2023:
         if is_mc :
             if "pre_BPix" in tag:
-                folderKey = "Run3-23CSep23-Summer23-NanoAODv12/2026-04-13"
-                L1Key = "Summer23Prompt23_V3_MC_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer23Prompt23_V3_MC_L2Relative_AK4PFPuppi"
-                L3Key = "Summer23Prompt23_V3_MC_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer23Prompt23_V3_MC_L2L3Residual_AK4PFPuppi"
-                scaleTotalKey = "Summer23Prompt23_V3_MC_Total_AK4PFPuppi"
+                folderKey = "Run3-23CSep23-Summer23-NanoAODv12/2026-06-05"
+                L1Key = "Summer23Prompt23_V4_MC_L1FastJet_AK4PFPuppi"
+                L2Key = "Summer23Prompt23_V4_MC_L2Relative_AK4PFPuppi"
+                L3Key = "Summer23Prompt23_V4_MC_L3Absolute_AK4PFPuppi"
+                L2L3Key = "Summer23Prompt23_V4_MC_L2L3Residual_AK4PFPuppi"
+                scaleTotalKey = "Summer23Prompt23_V4_MC_Total_AK4PFPuppi"
                 scaleKeyRegrouped11 = [
-                f"Summer23Prompt23_V3_MC_{label.format(year='2023')}_AK4PFPuppi" for label in jes_systematics_11split
+                f"Summer23Prompt23_V4_MC_{label.format(year='2023')}_AK4PFPuppi" for label in jes_systematics_11split
                 ]
                 smearKey = "JERSmear"
-                JERKey = "Summer23Prompt23_RunCv1234_JRV1_MC_PtResolution_AK4PFPuppi"
-                JERsfKey = "Summer23Prompt23_RunCv1234_JRV1_MC_ScaleFactor_AK4PFPuppi"
+                JERKey = "Summer23Prompt23_RunCv1234_JRV2_MC_PtResolution_AK4PFPuppi"
+                JERsfKey = "Summer23Prompt23_RunCv1234_JRV2_MC_ScaleFactor_AK4PFPuppi"
+                JERsfUncKey = "Summer23Prompt23_RunCv1234_JRV2_MC_SFUncertainty_AK4PFPuppi"
             else:
-                folderKey = "Run3-23DSep23-Summer23BPix-NanoAODv12/2026-04-13"
-                L1Key = "Summer23BPixPrompt23_V3_MC_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer23BPixPrompt23_V3_MC_L2Relative_AK4PFPuppi"
-                L3Key = "Summer23BPixPrompt23_V3_MC_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer23BPixPrompt23_V3_MC_L2L3Residual_AK4PFPuppi"
-                scaleTotalKey = "Summer23BPixPrompt23_V3_MC_Total_AK4PFPuppi"
+                folderKey = "Run3-23DSep23-Summer23BPix-NanoAODv12/2026-06-05"
+                L1Key = "Summer23BPixPrompt23_V4_MC_L1FastJet_AK4PFPuppi"
+                L2Key = "Summer23BPixPrompt23_V4_MC_L2Relative_AK4PFPuppi"
+                L3Key = "Summer23BPixPrompt23_V4_MC_L3Absolute_AK4PFPuppi"
+                L2L3Key = "Summer23BPixPrompt23_V4_MC_L2L3Residual_AK4PFPuppi"
+                scaleTotalKey = "Summer23BPixPrompt23_V4_MC_Total_AK4PFPuppi"
                 scaleKeyRegrouped11 = [
-                f"Summer23BPixPrompt23_V3_MC_{label.format(year='2023BPix')}_AK4PFPuppi" for label in jes_systematics_11split
+                f"Summer23BPixPrompt23_V4_MC_{label.format(year='2023BPix')}_AK4PFPuppi" for label in jes_systematics_11split
                 ]
                 smearKey = "JERSmear"
-                JERKey = "Summer23BPixPrompt23_RunD_JRV1_MC_PtResolution_AK4PFPuppi"
-                JERsfKey = "Summer23BPixPrompt23_RunD_JRV1_MC_ScaleFactor_AK4PFPuppi"
+                JERKey = "Summer23BPixPrompt23_RunD_JRV2_MC_PtResolution_AK4PFPuppi"
+                JERsfKey = "Summer23BPixPrompt23_RunD_JRV2_MC_ScaleFactor_AK4PFPuppi"
+                JERsfUncKey = "Summer23BPixPrompt23_RunD_JRV2_MC_SFUncertainty_AK4PFPuppi"
         ## Data
         ## JER are not applied to data
         else :
             if "pre_BPix" in tag:
-                folderKey = "Run3-23CSep23-Summer23-NanoAODv12/2026-04-13"
-                L1Key = "Summer23Prompt23_V3_DATA_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer23Prompt23_V3_DATA_L2Relative_AK4PFPuppi"
-                L3Key = "Summer23Prompt23_V3_DATA_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer23Prompt23_V3_DATA_L2L3Residual_AK4PFPuppi"
+                folderKey = "Run3-23CSep23-Summer23-NanoAODv12/2026-06-05"
+                L1Key = "Summer23Prompt23_V4_DATA_L1FastJet_AK4PFPuppi"
+                L2Key = "Summer23Prompt23_V4_DATA_L2Relative_AK4PFPuppi"
+                L3Key = "Summer23Prompt23_V4_DATA_L3Absolute_AK4PFPuppi"
+                L2L3Key = "Summer23Prompt23_V4_DATA_L2L3Residual_AK4PFPuppi"
                 scaleTotalKey = None
                 scaleKeyRegrouped11 = None 
                 smearKey = None
                 JERKey = None
                 JERsfKey = None
+                JERsfUncKey = None
             else:
-                folderKey = "Run3-23DSep23-Summer23BPix-NanoAODv12/2025-10-07"
-                L1Key = "Summer23BPixPrompt23_V3_DATA_L1FastJet_AK4PFPuppi"
-                L2Key = "Summer23BPixPrompt23_V3_DATA_L2Relative_AK4PFPuppi"
-                L3Key = "Summer23BPixPrompt23_V3_DATA_L3Absolute_AK4PFPuppi"
-                L2L3Key = "Summer23BPixPrompt23_V3_DATA_L2L3Residual_AK4PFPuppi"
+                folderKey = "Run3-23DSep23-Summer23BPix-NanoAODv12/2026-06-05"
+                L1Key = "Summer23BPixPrompt23_V4_DATA_L1FastJet_AK4PFPuppi"
+                L2Key = "Summer23BPixPrompt23_V4_DATA_L2Relative_AK4PFPuppi"
+                L3Key = "Summer23BPixPrompt23_V4_DATA_L3Absolute_AK4PFPuppi"
+                L2L3Key = "Summer23BPixPrompt23_V4_DATA_L2L3Residual_AK4PFPuppi"
                 scaleTotalKey = None
                 scaleKeyRegrouped11 = None 
                 smearKey = None
                 JERKey = None
                 JERsfKey = None
+                JERsfUncKey = None
 
     elif era == 2024:
         if is_mc :
-            folderKey = "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-12-02"
-            L1Key = "Summer24Prompt24_V2_MC_L1FastJet_AK4PFPuppi"
-            L2Key = "Summer24Prompt24_V2_MC_L2Relative_AK4PFPuppi"
-            L3Key = "Summer24Prompt24_V2_MC_L3Absolute_AK4PFPuppi"
-            L2L3Key = "Summer24Prompt24_V2_MC_L2L3Residual_AK4PFPuppi"
-            scaleTotalKey = "Summer24Prompt24_V2_MC_Total_AK4PFPuppi"
+            folderKey = "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-06-05"
+            L1Key = "Summer24Prompt24_V3_MC_L1FastJet_AK4PFPuppi"
+            L2Key = "Summer24Prompt24_V3_MC_L2Relative_AK4PFPuppi"
+            L3Key = "Summer24Prompt24_V3_MC_L3Absolute_AK4PFPuppi"
+            L2L3Key = "Summer24Prompt24_V3_MC_L2L3Residual_AK4PFPuppi"
+            scaleTotalKey = "Summer24Prompt24_V3_MC_Total_AK4PFPuppi"
             scaleKeyRegrouped11 = [
-                f"Summer24Prompt24_V2_MC_{label.format(year='2024')}_AK4PFPuppi" for label in jes_systematics_11split
+                f"Summer24Prompt24_V3_MC_{label.format(year='2024')}_AK4PFPuppi" for label in jes_systematics_11split
                 ]
             smearKey = "JERSmear"
             # It appears the 23Bpix keys are used for the following:
-            JERKey = "Summer23BPixPrompt23_RunD_JRV1_MC_PtResolution_AK4PFPuppi"
-            JERsfKey = "Summer23BPixPrompt23_RunD_JRV1_MC_ScaleFactor_AK4PFPuppi"
- 
+            JERKey = "Summer24Prompt24_JRV1_MC_PtResolution_AK4PFPuppi"
+            JERsfKey = "Summer24Prompt24_JRV1_MC_ScaleFactor_AK4PFPuppi"
+            JERsfUncKey = "Summer24Prompt24_JRV1_MC_SFUncertainty_AK4PFPuppi"
         else :
             # folderKey = "2024_Winter24" # JERC file md5sum: a0c4f7f29e09162f56c07a9b5fb97d1e
             # L1Key = "Winter24Prompt24_V3_DATA_L1FastJet_AK4PFPuppi"
             # L2Key = "Winter24Prompt24_V3_DATA_L2Relative_AK4PFPuppi"
             # L3Key = "Winter24Prompt24_V3_DATA_L3Absolute_AK4PFPuppi"
             # L2L3Key = "Winter24Prompt24_V3_DATA_L2L3Residual_AK4PFPuppi"
-            folderKey = "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2025-12-02"
-            L1Key = "Summer24Prompt24_V2_DATA_L1FastJet_AK4PFPuppi"
-            L2Key = "Summer24Prompt24_V2_DATA_L2Relative_AK4PFPuppi"
-            L3Key = "Summer24Prompt24_V2_DATA_L3Absolute_AK4PFPuppi"
-            L2L3Key = "Summer24Prompt24_V2_DATA_L2L3Residual_AK4PFPuppi"
+            folderKey = "Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/2026-06-05"
+            L1Key = "Summer24Prompt24_V3_DATA_L1FastJet_AK4PFPuppi"
+            L2Key = "Summer24Prompt24_V3_DATA_L2Relative_AK4PFPuppi"
+            L3Key = "Summer24Prompt24_V3_DATA_L3Absolute_AK4PFPuppi"
+            L2L3Key = "Summer24Prompt24_V3_DATA_L2L3Residual_AK4PFPuppi"
             scaleTotalKey = None
             scaleKeyRegrouped11 = None 
             smearKey = None
             JERKey = None
             JERsfKey = None
+            JERsfUncKey = None
 
     else:
         raise ValueError("getJetCorrected: Era", era, tag, "not supported")
@@ -212,4 +223,4 @@ def getJetCorrected(era, tag, is_mc, useJesSplittingScheme11, overwritePt=True) 
 
     print("***jetJERC: era:", era, "tag:", tag, "is MC:", is_mc, "overwritePt:", overwritePt, "phiDependent:", usePhiDependentJEC, "runDependent:", useRunDependentJEC, "JesSplittingScheme11:", useJesSplittingScheme11,"json_JERC:", json_JERC, "json_JERsmear:", json_JERsmear)
     
-    return jetJERC(era, json_JERC, json_JERsmear, L1Key, L2Key, L3Key, L2L3Key, scaleKey, smearKey, JERKey, JERsfKey, overwritePt, usePhiDependentJEC, useRunDependentJEC)
+    return jetJERC(era, json_JERC, json_JERsmear, L1Key, L2Key, L3Key, L2L3Key, scaleKey, smearKey, JERKey, JERsfKey, JERsfUncKey, overwritePt, usePhiDependentJEC, useRunDependentJEC)

--- a/checkout_13X.csh
+++ b/checkout_13X.csh
@@ -66,7 +66,7 @@ sed -i '/SimTracker\/Records/d' KinZfitter/HelperFunction/BuildFile.xml
 sed -i '/SimTracker\/Records/d' KinZfitter/KinZfitter/BuildFile.xml
 sed -i '/#include "RooMinuit.h"/d' KinZfitter/KinZfitter/interface/KinZfitter.h
 
-#Fix some memory issues (#47289 queued CMSSW_15_0_X))
+#Fix some memory issues (#47289, released since CMSSW_15_1_0)
 git cms-addpkg PhysicsTools/NanoAODTools
 git fetch https://github.com/namapane/cmssw.git NAT-dev2:namapane_NAT-dev2
 git cherry-pick aa9ecbd04d6 98f8692142f
@@ -87,7 +87,7 @@ fi
    
 #get nanoAODTools modules
 git clone https://github.com/cms-cat/nanoAOD-tools-modules.git PhysicsTools/NATModules
-(cd PhysicsTools/NATModules; git checkout -b from-f2f8851 f2f8851)
+(cd PhysicsTools/NATModules; git checkout -b from-bf18407 bf18407)
 
 
 #CommonLHETools requires the MELA env to be set for compilation


### PR DESCRIPTION
Dear Experts,

This is to update to the new version of JERC correctionlib json.gz [1,2]. The major change is that the keys for JER SF and JER SF unc are different now. Follow the PR in nanoAOD-tools-modules [3]. Once that PR is merged, I will update the commit code in `checkout_13X.csh` too.
Thanks!

Yours Sincerely,
Geliang

[1] https://github.com/cms-jet/JRDatabase/pull/30
[2] https://cms-talk.web.cern.ch/t/new-jer-smearing-inputs-available-for-2024-and-2025/145723
[3] https://github.com/cms-cat/nanoAOD-tools-modules/pull/32