### PR TITLE
Compute JES/JER-varied MELA probabilities

### DIFF
--- a/NanoAnalysis/python/MELAProbHelper.py
+++ b/NanoAnalysis/python/MELAProbHelper.py
@@ -13,12 +13,26 @@ class MELAProbHelper():
     A probability with context defined as "Any" will be computed at lhe and reco level.  
     """
 
+    # These production modes consume associated jets in MELA.  ``Prod`` alone
+    # is not sufficient in the general helper because production modes can
+    # instead use associated leptons, photons, or heavy quarks.
+    jetDependentProductions = {
+        "JQCD", "JJQCD", "JJVBF", "JJEW", "JJEWQCD",
+        "JJQCD_S", "JJVBF_S", "JJEW_S", "JJEWQCD_S",
+        "JJQCD_TU", "JJVBF_TU", "JJEW_TU", "JJEWQCD_TU",
+        "Had_WH", "Had_ZH", "Had_WH_S", "Had_ZH_S",
+        "Had_WH_TU", "Had_ZH_TU",
+    }
+    # Persisted value when the selected-jet multiplicity cannot support a ME.
+    notApplicableValue = -999.
+
     def __init__(self, MELA, MELASettings, ModuleContext, candColl="ZZCand"):
         self.MELA = MELA
         self.sortedSettings = []
         self.ModuleContext = ModuleContext
         self.candColl = candColl
         self.names = []
+        self.jetVariations = []
         
         if ModuleContext not in ["LHE", "Reco"] :
             raise valueError("MELAProbHelper: invalid ModuleContext", ModuleContext)
@@ -85,6 +99,51 @@ class MELAProbHelper():
                         raise(ValueError(f"MELAProbHelper: for {prob['Name']}: 'dividep' is supported only for 'context=LHE'"))                    
                 else:
                     prob["dividep_idx"] = self.names.index(dp) # Index of probability to be used as denominator.
+
+    def setJetVariations(self, jetVariations):
+        self.jetVariations = list(jetVariations)
+
+    def _isJetDependent(self, prob):
+        return (
+            self.ModuleContext == "Reco"
+            and bool(prob["Prod"])
+            and prob["Production"] in self.jetDependentProductions
+        )
+
+    @staticmethod
+    def _jetProbabilitySignature(prob):
+        """Identify settings that have the same matrix-element calculation."""
+        couplings = tuple(sorted(
+            (name, tuple(value) if isinstance(value, (list, tuple)) else value)
+            for name, value in prob["Couplings"].items()
+        ))
+        return (
+            prob["Process"], prob["MatrixElement"], prob["Production"],
+            bool(prob["Prod"]), bool(prob["Dec"]), couplings,
+            bool(prob["useconstant"]), bool(prob["match_mX"]),
+            bool(prob["separatewwzz"]), prob["lepton_interference"],
+        )
+
+    @staticmethod
+    def _variedBranchName(branchname, variation):
+        nominalSuffix = "_JECNominal"
+        if branchname.endswith(nominalSuffix):
+            return branchname[:-len(nominalSuffix)] + "_" + variation
+        return branchname + "_" + variation
+
+    def _bookVariedOutputs(self, prob, lenVar):
+        if not self._isJetDependent(prob):
+            return
+        for variation in self.jetVariations:
+            branchname = self._variedBranchName(prob["branchname"], variation)
+            title = f"User-defined Reco-level probability for jet variation {variation}"
+            self.out.branch(branchname, "F", lenVar=lenVar, limitedPrecision=16, title=title)
+            if prob["addPAux"]:
+                self.out.branch(branchname + "_aux", "F", lenVar=lenVar, limitedPrecision=16, title=title + " auxiliary")
+            if prob["addPmavjj"]:
+                self.out.branch(branchname + "_mavjj", "F", lenVar=lenVar, title=title + " mavjj")
+            if prob["addPmavjj_true"]:
+                self.out.branch(branchname + "_mavjj_true", "F", lenVar=lenVar, title=title + " mavjj true")
         
     def bookProbs(self, wrappedOutputTree): 
         #this needs a per-module lenVar. 
@@ -112,9 +171,152 @@ class MELAProbHelper():
                     self.out.branch(prob["branchname"]+"_mavjj", "F", lenVar=lenVar_, title="User-defined mavjj probability")
                 if prob["addPmavjj_true"]:
                     self.out.branch(prob["branchname"]+"_mavjj_true", "F", lenVar=lenVar_, title="User-defined mavjj_true probability")
-    def fillProbs(self, candDaughters, candAssociated, candMothers): 
+                self._bookVariedOutputs(prob, lenVar_)
+
+    @staticmethod
+    def _minimumSelectedJets(production):
+        if production in {"JQCD"}:
+            return 1
+        if production.startswith(("JJQCD", "JJVBF", "JJEW")):
+            return 1
+        if production.startswith(("Had_WH", "Had_ZH")):
+            return 2
+        return 0
+
+    def _fillJetVariedProbs(self, candDaughters, candAssociatedVariations, selectedJetCounts):
+        """Set each shifted event once, then evaluate all jet probabilities."""
+        if not self.jetVariations:
+            return
+
+        states = []
+        for prob in self.sortedSettings:
+            if not self._isJetDependent(prob):
+                continue
+            states.append({
+                "prob": prob,
+                "signature": self._jetProbabilitySignature(prob),
+                "minimumJets": self._minimumSelectedJets(prob["Production"]),
+                "process": check_enum(prob["Process"], Mela.Process),
+                "matrixElement": check_enum(prob["MatrixElement"], Mela.MatrixElement),
+                "production": check_enum(prob["Production"], Mela.Production),
+                "leptonInterference": check_enum(prob["lepton_interference"], Mela.LeptonInterference),
+            })
+        if not states:
+            return
+
+        signaturesNeedingPAux = {
+            state["signature"] for state in states if state["prob"]["addPAux"]
+        }
+        signaturesNeedingMavjj = {
+            state["signature"] for state in states if state["prob"]["addPmavjj"]
+        }
+        signaturesNeedingMavjjTrue = {
+            state["signature"] for state in states if state["prob"]["addPmavjj_true"]
+        }
+
+        outputs = {}
+        for state in states:
+            prob = state["prob"]
+            for variation in self.jetVariations:
+                outputs[(prob["branchname"], variation)] = {
+                    "probability": [self.notApplicableValue]*len(candDaughters),
+                    "aux": [self.notApplicableValue]*len(candDaughters) if prob["addPAux"] else None,
+                    "mavjj": [self.notApplicableValue]*len(candDaughters) if prob["addPmavjj"] else None,
+                    "mavjj_true": [self.notApplicableValue]*len(candDaughters) if prob["addPmavjj_true"] else None,
+                }
+
+        for variation in self.jetVariations:
+            nSelectedJets = selectedJetCounts[variation]
+            for iCand in range(len(candDaughters)):
+                eligibleStates = [
+                    state for state in states
+                    if nSelectedJets >= state["minimumJets"]
+                ]
+
+                for state in states:
+                    if state in eligibleStates:
+                        continue
+                    result = outputs[(state["prob"]["branchname"], variation)]
+                    result["probability"][iCand] = self.notApplicableValue
+                    for name in ("aux", "mavjj", "mavjj_true"):
+                        if result[name] is not None:
+                            result[name][iCand] = self.notApplicableValue
+
+                if not eligibleStates:
+                    continue
+
+                self.MELA.setInputEvent(
+                    candDaughters[iCand],
+                    candAssociatedVariations[variation][iCand],
+                    None,
+                    0,
+                )
+                try:
+                    cache = {}
+                    for state in eligibleStates:
+                        prob = state["prob"]
+                        signature = state["signature"]
+                        result = outputs[(prob["branchname"], variation)]
+
+                        if signature not in cache:
+                            self.MELA.setProcess(
+                                state["process"],
+                                state["matrixElement"],
+                                state["production"],
+                            )
+                            self.MELA.differentiate_HWW_HZZ = prob["separatewwzz"]
+                            self.MELA.setMelaLeptonInterference(state["leptonInterference"])
+                            for coupl, coupl_val in prob["Couplings"].items():
+                                setattr(self.MELA, coupl, coupl_val)
+                            if prob["match_mX"]:
+                                mass = candDaughters[iCand].MTotal()
+                                self.MELA.setMelaHiggsMassWidth(mass, 0.00001, 0)
+                                self.MELA.setMelaHiggsMassWidth(mass, 0.00001, 1)
+
+                            if prob["Prod"] and prob["Dec"]:
+                                probability = self.MELA.computeProdDecP(prob["useconstant"])
+                            else:
+                                probability = self.MELA.computeProdP(prob["useconstant"])
+                            cached = {
+                                "probability": probability,
+                                "aux": None,
+                                "mavjj": None,
+                                "mavjj_true": None,
+                            }
+                            if signature in signaturesNeedingPAux:
+                                cached["aux"] = self.MELA.getPAux()
+                            if signature in signaturesNeedingMavjj:
+                                cached["mavjj"] = self.MELA.computeDijetConvBW(False)
+                            if signature in signaturesNeedingMavjjTrue:
+                                cached["mavjj_true"] = self.MELA.computeDijetConvBW(True)
+                            cache[signature] = cached
+
+                        cached = cache[signature]
+                        result["probability"][iCand] = cached["probability"]
+                        for name in ("aux", "mavjj", "mavjj_true"):
+                            if result[name] is not None:
+                                result[name][iCand] = cached[name]
+                finally:
+                    self.MELA.resetInputEvent()
+
+        for state in states:
+            prob = state["prob"]
+            for variation in self.jetVariations:
+                result = outputs[(prob["branchname"], variation)]
+                branchname = self._variedBranchName(prob["branchname"], variation)
+                self.out.fillBranch(branchname, result["probability"])
+                if result["aux"] is not None:
+                    self.out.fillBranch(branchname + "_aux", result["aux"])
+                if result["mavjj"] is not None:
+                    self.out.fillBranch(branchname + "_mavjj", result["mavjj"])
+                if result["mavjj_true"] is not None:
+                    self.out.fillBranch(branchname + "_mavjj_true", result["mavjj_true"])
+
+    def fillProbs(self, candDaughters, candAssociated, candMothers,
+                  candAssociatedVariations=None, selectedJetCounts=None,
+                  selectedJetCountNominal=None):
         if len(self.sortedSettings) == 0: return True
-        else: 
+        else:
             vprob = [0.]*len(self.sortedSettings) # to be used to retrieve denominators for probs whith dividep for the current cand
             for iprob, prob in enumerate(self.sortedSettings):
             ### Parse MELA settings for the desired probability
@@ -143,25 +345,33 @@ class MELAProbHelper():
                 self.MELA.setMelaLeptonInterference(MELA_leptoninterference)
 
                 # Define arrays to fill with the probabilites for each candidate
-                probVec = [-999.]*len(candDaughters)
+                probVec = [self.notApplicableValue]*len(candDaughters)
                 if MELA_ispm4l: 
-                    probVec_ScaleUp = [-999.]*len(candDaughters)
-                    probVec_ScaleDown = [-999.]*len(candDaughters)
-                    probVec_SystUp = [-999.]*len(candDaughters)
-                    probVec_SystDown = [-999.]*len(candDaughters)
+                    probVec_ScaleUp = [self.notApplicableValue]*len(candDaughters)
+                    probVec_ScaleDown = [self.notApplicableValue]*len(candDaughters)
+                    probVec_SystUp = [self.notApplicableValue]*len(candDaughters)
+                    probVec_SystDown = [self.notApplicableValue]*len(candDaughters)
                 if MELA_computeprop: 
-                    probPropVec = [-999.]*len(candDaughters)
+                    probPropVec = [self.notApplicableValue]*len(candDaughters)
 
                 if MELA_addPAux:
-                    probVec_PAux = [-999.]*len(candDaughters)
+                    probVec_PAux = [self.notApplicableValue]*len(candDaughters)
 
                 if MELA_addPmavjj:
-                    probVec_mavjj = [-999.]*len(candDaughters)
+                    probVec_mavjj = [self.notApplicableValue]*len(candDaughters)
                 if MELA_addPmavjj_true:
-                    probVec_mavjj_true = [-999.]*len(candDaughters)
+                    probVec_mavjj_true = [self.notApplicableValue]*len(candDaughters)
+
+                nominalProbabilityIsApplicable = (
+                    selectedJetCountNominal is None
+                    or not self._isJetDependent(prob)
+                    or selectedJetCountNominal >= self._minimumSelectedJets(prob["Production"])
+                )
 
                 # Compute prob for each candidate
                 for iCand, aCand in enumerate(candDaughters):
+                    if not nominalProbabilityIsApplicable:
+                        continue
                     
                     for coupl, coupl_val in prob["Couplings"].items(): 
                         setattr(self.MELA, coupl, coupl_val)
@@ -249,9 +459,15 @@ class MELAProbHelper():
                     self.out.fillBranch(MELA_branchname+"_mavjj", probVec_mavjj)
                 if MELA_addPmavjj_true:
                     self.out.fillBranch(MELA_branchname+"_mavjj_true", probVec_mavjj_true)
-                
+
+            if candAssociatedVariations is not None and selectedJetCounts is not None:
+                self._fillJetVariedProbs(
+                    candDaughters,
+                    candAssociatedVariations,
+                    selectedJetCounts,
+                )
+
         return True
         
 
                         
-

--- a/NanoAnalysis/python/RecoProbFiller.py
+++ b/NanoAnalysis/python/RecoProbFiller.py
@@ -1,4 +1,5 @@
 import copy
+import math
 from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
 from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection
 from ZZAnalysis.NanoAnalysis.MELAProbHelper import MELAProbHelper
@@ -24,6 +25,42 @@ class RecoProbFiller(Module):
         print("***RecoProbFiller: set for: ", self.probHelpers["ZZCand"].names,
               "processCR:", self.processCR, flush=True)
         self.filler = {}
+        self.jetVariations = []
+
+    def setJetVariations(self, jetCorrector):
+        """Configure the JES/JER kinematic points produced upstream.
+
+        The jet-correction module owns the exact JES labels, so deriving the
+        list from that module keeps the MELA output synchronized with either
+        the split-11 or total-JES configuration.  Data have no shifted jets.
+        """
+        hasJetDependentProbabilities = any(
+            probHelper._isJetDependent(prob)
+            for probHelper in self.probHelpers.values()
+            for prob in probHelper.sortedSettings
+        )
+        if not getattr(jetCorrector, "is_mc", False) or not hasJetDependentProbabilities:
+            self.jetVariations = []
+        elif isinstance(jetCorrector.evaluator_JES, dict):
+            self.jetVariations = [
+                f"{label}_{direction}"
+                for label in jetCorrector.evaluator_JES
+                for direction in ("ScaleUp", "ScaleDn")
+            ]
+        else:
+            self.jetVariations = ["scaleUp", "scaleDn"]
+        if getattr(jetCorrector, "is_mc", False) and hasJetDependentProbabilities:
+            self.jetVariations.extend(("smearUp", "smearDn"))
+
+        # Jet-varied MELA probabilities belong only to the signal-region
+        # ZZCand collection.  Keep nominal probabilities for the ZLL control
+        # region, but never book or compute JES/JER probability variations.
+        for candColl, probHelper in self.probHelpers.items():
+            probHelper.setJetVariations(
+                self.jetVariations if candColl == "ZZCand" else []
+            )
+
+        print("***RecoProbFiller: jet-varied MELA points:", self.jetVariations, flush=True)
 
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
@@ -75,15 +112,73 @@ class RecoProbFiller(Module):
 
         return candsDaughters, candsAssociated
 
+    @staticmethod
+    def _particleFromPtEtaPhiM(pdgId, pt, eta, phi, mass):
+        px = pt * math.cos(phi)
+        py = pt * math.sin(phi)
+        pz = pt * math.sinh(eta)
+        energy = math.sqrt(max(mass * mass + px * px + py * py + pz * pz, 0.))
+        return Mela.SimpleParticle_t(pdgId, px, py, pz, energy)
+
+    def _selectVariedJets(self, jets, variation):
+        """Return shifted leading/subleading jets after the nominal selection.
+
+        Jet-lepton cleaning is reevaluated because ``Jet_ZZLepEF`` has the
+        nominal jet pt in its denominator.  Nothing from this temporary
+        selection is written to the output tree.
+        """
+        selected = []
+        for idx, jet in enumerate(jets):
+            pt = getattr(jet, variation + "_pt")
+            mass = getattr(jet, variation + "_mass")
+            leptonPt = jet.ZZLepEF * jet.pt
+            overlapsLeptons = pt <= 0. or leptonPt / pt > 0.5
+            if overlapsLeptons or jet.jetId != 6 or pt <= jet.ptThreshold:
+                continue
+            selected.append((pt, idx, mass))
+        selected.sort(key=lambda item: item[0], reverse=True)
+        return selected[:2]
+
+    def _buildVariedAssociated(self, cands, leps, jets):
+        """Build per-candidate associated objects for every jet variation."""
+        associatedVariations = {}
+        selectedJetCounts = {}
+        for variation in self.jetVariations:
+            selectedJets = self._selectVariedJets(jets, variation)
+            selectedJetCounts[variation] = len(selectedJets)
+            varied = []
+            for aCand in cands:
+                associated = Mela.SimpleParticleCollection_t()
+                for pt, idx, mass in selectedJets:
+                    jet = jets[idx]
+                    associated.add_particle(self._particleFromPtEtaPhiM(
+                        0, pt, jet.eta, jet.phi, mass
+                    ))
+                for idx in (aCand.extraLep1Idx, aCand.extraLep2Idx):
+                    if idx < 0:
+                        continue
+                    lep = leps[idx]
+                    p4 = lep.p4()
+                    associated.add_particle(Mela.SimpleParticle_t(
+                        lep.pdgId, p4.Px(), p4.Py(), p4.Pz(), p4.E()
+                    ))
+                varied.append(associated)
+            associatedVariations[variation] = varied
+        return associatedVariations, selectedJetCounts
+
     def analyze(self, event):
         leps = Collection(event, 'Lepton')
         fsrPhotons = Collection(event, "FsrPhoton")
         jets = Collection(event, 'Jet')
+        selectedJetCountNominal = sum(
+            idx >= 0 for idx in (event.JetLeadingIdx, event.JetSubleadingIdx)
+        )
 
         for collName, probHelper in self.probHelpers.items():
             cands = Collection(event, collName)
             theFiller = self.filler[collName]
             candsDaughters, candsAssociated = self._buildMELAInputs(cands, event, leps, fsrPhotons, jets)
+            candsAssociatedVariations, selectedJetCounts = self._buildVariedAssociated(cands, leps, jets)
             for c in candsDaughters:
                 self.MELA.setInputEvent(c, None, None, False)
                 qH, mZ1, mZ2, helcosthetaZ1, helcosthetaZ2, helPhi, costhetastar, phistarZ1 = self.MELA.computeDecayAngles() 
@@ -94,7 +189,14 @@ class RecoProbFiller(Module):
                 theFiller.appendValue(collName + "_Phi1", phistarZ1)
             theFiller.fillBranches(cands)
             if self.MELASettings is not None:
-                probHelper.fillProbs(candsDaughters, candsAssociated, None)
+                probHelper.fillProbs(
+                    candsDaughters,
+                    candsAssociated,
+                    None,
+                    candAssociatedVariations=candsAssociatedVariations,
+                    selectedJetCounts=selectedJetCounts,
+                    selectedJetCountNominal=selectedJetCountNominal,
+                )
         return True
 
     def getDressedP4(self, lep, fsrPhotons):

--- a/NanoAnalysis/python/RecoProbFiller.py
+++ b/NanoAnalysis/python/RecoProbFiller.py
@@ -5,6 +5,7 @@ from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collect
 from ZZAnalysis.NanoAnalysis.MELAProbHelper import MELAProbHelper
 from ZZAnalysis.NanoAnalysis.tools import branchCollection
 import Mela
+from operator import itemgetter
 
 
 class RecoProbFiller(Module):
@@ -19,6 +20,7 @@ class RecoProbFiller(Module):
         self.NANOVERSION = NANOVERSION
         self.MELASettings = MELASettings
         self.processCR = processCR
+        self.EFthreshold = 0.5 # threshold of leptons pt over jet pt to veto the jet, to be reapplied to the varied jets. See the nominal one in jetFiller.py
         self.probHelpers = {"ZZCand": MELAProbHelper(self.MELA, self.MELASettings, "Reco", candColl="ZZCand")}
         if self.processCR:
             self.probHelpers["ZLLCand"] = MELAProbHelper(self.MELA, self.MELASettings, "Reco", candColl="ZLLCand")
@@ -112,13 +114,6 @@ class RecoProbFiller(Module):
 
         return candsDaughters, candsAssociated
 
-    @staticmethod
-    def _particleFromPtEtaPhiM(pdgId, pt, eta, phi, mass):
-        px = pt * math.cos(phi)
-        py = pt * math.sin(phi)
-        pz = pt * math.sinh(eta)
-        energy = math.sqrt(max(mass * mass + px * px + py * py + pz * pz, 0.))
-        return Mela.SimpleParticle_t(pdgId, px, py, pz, energy)
 
     def _selectVariedJets(self, jets, variation):
         """Return shifted leading/subleading jets after the nominal selection.
@@ -128,40 +123,51 @@ class RecoProbFiller(Module):
         selection is written to the output tree.
         """
         selected = []
+        pt_name = variation + "_pt"
+        mass_name = variation + "_mass"
         for idx, jet in enumerate(jets):
-            pt = getattr(jet, variation + "_pt")
-            mass = getattr(jet, variation + "_mass")
-            leptonPt = jet.ZZLepEF * jet.pt
-            overlapsLeptons = pt <= 0. or leptonPt / pt > 0.5
-            if overlapsLeptons or jet.jetId != 6 or pt <= jet.ptThreshold:
+            if jet.jetId != 6:
                 continue
+            pt = getattr(jet, pt_name)
+            leptonPt = jet.ZZLepEF * jet.pt
+            overlapsLeptons = pt <= 0. or leptonPt / pt > self.EFthreshold
+            if overlapsLeptons or pt <= jet.ptThreshold:
+                continue
+            mass = getattr(jet, mass_name)
             selected.append((pt, idx, mass))
-        selected.sort(key=lambda item: item[0], reverse=True)
+        selected.sort(key=itemgetter(0), reverse=True)
         return selected[:2]
 
     def _buildVariedAssociated(self, cands, leps, jets):
         """Build per-candidate associated objects for every jet variation."""
         associatedVariations = {}
         selectedJetCounts = {}
+        associatedLeptons = {}
+        for iCand, aCand in enumerate(cands):
+            associatedLeptons[iCand] = []
+            for idx in (aCand.extraLep1Idx, aCand.extraLep2Idx):
+                if idx < 0:
+                    continue
+                lep = leps[idx]
+                p4 = lep.p4()
+                associatedLeptons[iCand].append(Mela.SimpleParticle_t(
+                    lep.pdgId, p4.Px(), p4.Py(), p4.Pz(), p4.E()
+                ))
         for variation in self.jetVariations:
             selectedJets = self._selectVariedJets(jets, variation)
             selectedJetCounts[variation] = len(selectedJets)
             varied = []
-            for aCand in cands:
+            for iCand, aCand in enumerate(cands):
                 associated = Mela.SimpleParticleCollection_t()
                 for pt, idx, mass in selectedJets:
                     jet = jets[idx]
-                    associated.add_particle(self._particleFromPtEtaPhiM(
-                        0, pt, jet.eta, jet.phi, mass
-                    ))
-                for idx in (aCand.extraLep1Idx, aCand.extraLep2Idx):
-                    if idx < 0:
-                        continue
-                    lep = leps[idx]
-                    p4 = lep.p4()
-                    associated.add_particle(Mela.SimpleParticle_t(
-                        lep.pdgId, p4.Px(), p4.Py(), p4.Pz(), p4.E()
-                    ))
+                    px = pt * math.cos(jet.phi)
+                    py = pt * math.sin(jet.phi)
+                    pz = pt * math.sinh(jet.eta)
+                    energy = math.sqrt(max(mass * mass + px * px + py * py + pz * pz, 0.))
+                    associated.add_particle(Mela.SimpleParticle_t(0, px, py, pz, energy))
+                for lep in associatedLeptons[iCand]:
+                    associated.add_particle(lep)
                 varied.append(associated)
             associatedVariations[variation] = varied
         return associatedVariations, selectedJetCounts

--- a/NanoAnalysis/python/jetFiller.py
+++ b/NanoAnalysis/python/jetFiller.py
@@ -15,7 +15,13 @@ class jetFiller(Module):
     def __init__(self, year):
         print("***jetFiller", flush=True)
         self.dRMin = 0.4 # dR between lepton (or FSR) and jet to assume overlap
-        self.EFthreshold = 0.5 # threshold of leptons pt over jet pt to veto the jet
+        self.EFthreshold = 0.5 
+        #############################################################################
+        # NOTE: This is the threshold of leptons pt over jet pt to veto the jet. It #
+        # is also used in RecoProbFiller to reapply the veto to the varied jets, and#
+        # should be kept consistent with this one.                                  #
+        #############################################################################
+
         self.year = year
 
     def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
@@ -91,6 +97,10 @@ class jetFiller(Module):
                 # Consider only jets passing  tight ID and tightLepVeto ID, cf. https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID13p6TeV#nanoAOD_Flags
                 # FIXME: To be checked/updated for Run2 
                 if jet.jetId == 6 :
+                    #############################################################################
+                    # NOTE: RecoProbFiller also uses the jet ID requirement, and should be kept #
+                    #consistent with this one.                                                  #
+                    #############################################################################
                     #Summary of applied pT cuts following JME recommendations:
                     #Jets with abs(eta) < 2.5 -> pt_cut = 30
                     #Jets with 2.5 <= abs(eta) < 3.0 -> pt_cut = 50 , Ref: https://gitlab.cern.ch/cms-jetmet/coordination/coordination/-/issues/113

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -57,6 +57,7 @@ IsSIGNAL = getConf("IsSIGNAL", False)
 ADD_ALLEVENTS = getConf("ADD_ALLEVENTS", IsSIGNAL) # if true, add a separate tree with gen-level variables for all events (not just those passing the candidate selection); by default, this is done for signal samples
 ADD_LHE_PROB = getConf("ADD_LHE_PROB", ADD_ALLEVENTS) # Add LHE angles and probabilities. This is in general the case whenever ADD_ALLEVENTS is true (ie for signals)
 JES_SPLITTING = getConf("JES_SPLITTING", True) # Whether to split JES variations into 11 components (if false, only up/down variations are produced, by summing all components in quadrature)
+COMPUTE_JET_VARIATIONS_MELA = getConf("COMPUTE_JET_VARIATIONS_MELA", True) # Compute MELA probabilities for JES/JER shifted jets
 
 FILTER_EVENTS = getConf("FILTER_EVENTS", 'Cands') # Filter to be applied on events. Currently supported:
                                                   # 'Cands' = any event with a SR or CR candidate (default)
@@ -207,9 +208,11 @@ reco_sequence = [lepFiller(cuts, LEPTON_SETUP, MUON_ID_BYMVA), # FSR and FSR-cor
                  jetFiller(year=LEPTON_SETUP), # Jets cleaning with leptons
                  ZZExtraFiller(IsMC, LEPTON_SETUP, DATA_TAG, PROCESS_CR, APPLYELECORR, APPLYMUCORR), # Additional variables to selected candidates
                  ]
+recoProbFiller = None
 if runMELA is not None:
     from ZZAnalysis.NanoAnalysis.RecoProbFiller import *
-    reco_sequence.append(RecoProbFiller(mela, NANOVERSION, melaSettings, processCR=PROCESS_CR))  #Reco level angles and probabilities. 
+    recoProbFiller = RecoProbFiller(mela, NANOVERSION, melaSettings, processCR=PROCESS_CR)
+    reco_sequence.append(recoProbFiller)  #Reco level angles and probabilities.
 
 # Add muon scale corrections
 if APPLYMUCORR :
@@ -225,13 +228,19 @@ if APPLYELECORR and (LEPTON_SETUP >=2022 or NANOVERSION>=15):
     from ZZAnalysis.NanoAnalysis.modules.eleScaleResProducer import getEleScaleRes
     insertBefore(reco_sequence, 'lepFiller', getEleScaleRes(LEPTON_SETUP, DATA_TAG, IsMC, overwritePt=True))
 
-# Add jet corrections for Run 3
-if APPLYJETCORR :
+# Add jet corrections and veto maps
+if APPLYJETCORR:
+    if LEPTON_SETUP >= 2022:  # FIXME: To be set up for Run2
+        from ZZAnalysis.NanoAnalysis.modules.jetJERC import getJetCorrected
+        jetCorrector = getJetCorrected(LEPTON_SETUP, DATA_TAG, IsMC, JES_SPLITTING, overwritePt=True)
+        insertBefore(reco_sequence, 'jetFiller', jetCorrector)
+        if recoProbFiller is not None and COMPUTE_JET_VARIATIONS_MELA:
+            recoProbFiller.setJetVariations(jetCorrector)
+        elif recoProbFiller is not None:
+            print("***RecoProbFiller: jet-varied MELA computation disabled", flush=True)
+
     from ZZAnalysis.NanoAnalysis.modules.jetVMAP import getJetVetoMap
     insertBefore(reco_sequence, 'jetFiller', getJetVetoMap(LEPTON_SETUP, DATA_TAG))
-    if LEPTON_SETUP >=2022 : # FIXME: To be set up for Run2
-        from ZZAnalysis.NanoAnalysis.modules.jetJERC import getJetCorrected    
-        insertBefore(reco_sequence, 'jetFiller', getJetCorrected(LEPTON_SETUP, DATA_TAG, IsMC, JES_SPLITTING, overwritePt=True))
 
 if LEPTON_SETUP >=2022 :
     from ZZAnalysis.NanoAnalysis.modules.jetBtagProducer import getJetBtagProducer

--- a/NanoAnalysis/python/nanoZZ4lAnalysis.py
+++ b/NanoAnalysis/python/nanoZZ4lAnalysis.py
@@ -57,7 +57,7 @@ IsSIGNAL = getConf("IsSIGNAL", False)
 ADD_ALLEVENTS = getConf("ADD_ALLEVENTS", IsSIGNAL) # if true, add a separate tree with gen-level variables for all events (not just those passing the candidate selection); by default, this is done for signal samples
 ADD_LHE_PROB = getConf("ADD_LHE_PROB", ADD_ALLEVENTS) # Add LHE angles and probabilities. This is in general the case whenever ADD_ALLEVENTS is true (ie for signals)
 JES_SPLITTING = getConf("JES_SPLITTING", True) # Whether to split JES variations into 11 components (if false, only up/down variations are produced, by summing all components in quadrature)
-COMPUTE_JET_VARIATIONS_MELA = getConf("COMPUTE_JET_VARIATIONS_MELA", True) # Compute MELA probabilities for JES/JER shifted jets
+COMPUTE_JET_VARIATIONS_MELA = getConf("COMPUTE_JET_VARIATIONS_MELA", False) # Compute MELA probabilities for JES/JER shifted jets
 
 FILTER_EVENTS = getConf("FILTER_EVENTS", 'Cands') # Filter to be applied on events. Currently supported:
                                                   # 'Cands' = any event with a SR or CR candidate (default)
@@ -236,8 +236,6 @@ if APPLYJETCORR:
         insertBefore(reco_sequence, 'jetFiller', jetCorrector)
         if recoProbFiller is not None and COMPUTE_JET_VARIATIONS_MELA:
             recoProbFiller.setJetVariations(jetCorrector)
-        elif recoProbFiller is not None:
-            print("***RecoProbFiller: jet-varied MELA computation disabled", flush=True)
 
     from ZZAnalysis.NanoAnalysis.modules.jetVMAP import getJetVetoMap
     insertBefore(reco_sequence, 'jetFiller', getJetVetoMap(LEPTON_SETUP, DATA_TAG))

--- a/NanoAnalysis/test/prod/pyFragments/STXS_probs.py
+++ b/NanoAnalysis/test/prod/pyFragments/STXS_probs.py
@@ -1,6 +1,7 @@
 from ZZAnalysis.NanoAnalysis.tools import setConf
 
 setConf("bestCandByMELA",True)
+setConf("COMPUTE_JET_VARIATIONS_MELA", True)
 
 setConf("probabilities", {
     "Name": "m4l_BKG",


### PR DESCRIPTION
Dear Experts,

I (and codex) managed to address the computation of JES/JER-varied MELA probabilities. Only 24 * 11 MELA probabilities are additionally selected; no intermediate variables like varied leading / subleading jet indices are saved.

Tests have been performed with 2022EE ggH125, VBFH125 and partially ZZTo4l. For ggH125, VBFH125, I performed with or without JES/JER-varied probabilities. The runtime and file sizes are reported below:
Sample | Nominal job-hours | With 24 variations | Slowdown | Nominal memory | Varied memory | Memory increase
-- | -- | -- | -- | -- | -- | --
ggH125 | 4.72 | 20.37 | 4.32× | 819.9 MiB | 893.5 MiB | +9.0%
VBFH125 | 1.39 | 9.26 | 6.68× | 222.3 MiB | 253.7 MiB | +14.1%

We can see that the runtime is significantly slower, but in any case this is the price we have to pay, no matter computing them here or in the preprocessor.

Besides, comparison plots of the up/down variations with the nominal ones are made. Plots showing the distributions are shown in [1], and ratios of variations divided by the nominal ones are shown in [2], for the three processes.

Please let me know if the results are acceptable.

Besides, in `nanoZZ4lAnalysis.py`, jetVetoMap is put after JERC.

Thanks!

Yours Sincerely,
Geliang

[1] https://geliu.web.cern.ch/HZZ4l_Run3/JetVariedMELA/jet_varied_mela/
[2] https://geliu.web.cern.ch/HZZ4l_Run3/JetVariedMELA/jet_varied_mela_ratio/
